### PR TITLE
Action committable even when it is late

### DIFF
--- a/src/api/action-groups/post-action-by-action-group-id.api.ts
+++ b/src/api/action-groups/post-action-by-action-group-id.api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 import { GetActionGroupRes } from './index.interface'
 
-export const postActionByActionGroupId = async (
+export const postActionByActionGroupIdApi = async (
   actionGroupId: string,
 ): Promise<CustomizedAxiosResponse<GetActionGroupRes>> => {
   const url = `/v1/action-groups/${actionGroupId}/actions`

--- a/src/atoms/StyledIconButtonWithMenu.tsx
+++ b/src/atoms/StyledIconButtonWithMenu.tsx
@@ -5,6 +5,7 @@ import StyledIconButtonAtom, {
 import { Menu, MenuItem } from '@mui/material'
 
 export interface PropsMenuItem {
+  id: string
   onClick: () => any
   title: string
   isDisabled?: boolean
@@ -32,6 +33,20 @@ const StyledIconButtonWithMenuAtom: FC<Props> = ({ menus, ...props }) => {
     [menus],
   )
 
+  const onClickMenu = useCallback(
+    async (e: MouseEvent<HTMLLIElement, globalThis.MouseEvent>) => {
+      // find the menu item
+      const id = e.currentTarget.id
+      const menuItem = menus.find((menu) => menu.id === id)
+      if (!menuItem) return
+
+      // close the menu
+      await menuItem.onClick()
+      onClose()
+    },
+    [menus, onClose],
+  )
+
   return (
     <Fragment>
       <StyledIconButtonAtom {...props} onClick={onClick} />
@@ -51,8 +66,9 @@ const StyledIconButtonWithMenuAtom: FC<Props> = ({ menus, ...props }) => {
       >
         {menus.map((menu) => (
           <MenuItem
+            id={menu.id}
             key={menu.title}
-            onClick={menu.onClick}
+            onClick={onClickMenu}
             disabled={menu.isDisabled}
           >
             {menu.title}

--- a/src/components/atom_user_avatar/index.end-user.tsx
+++ b/src/components/atom_user_avatar/index.end-user.tsx
@@ -24,14 +24,17 @@ const EndUserAvatar: FC = () => {
   const menuItems: PropsMenuItem[] = useMemo(
     () => [
       {
+        id: `buy_me_coffee`,
         title: `Buy me coffee!`,
         onClick: onClickBuyMeCoffee,
       },
       {
+        id: `to_mlajkim_profile`,
         title: `To mlajkim's profile`,
         onClick: onClickToAdminProfile,
       },
       {
+        id: `sign_out`,
         title: `Sign out`,
         onClick: onSignOutApp,
       },

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -1,39 +1,26 @@
-import { postActionByActionGroupId } from '@/api/action-groups/post-action-by-action-group-id.api'
 import StyledCircularButtonAtom from '@/atoms/StyledCircularButton'
 import { ActionGroupFixedId } from '@/constants/action-group.constant'
+import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
 import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
-import { FC, useState } from 'react'
-import { useRecoilCallback, useRecoilValue } from 'recoil'
+import { FC } from 'react'
+import { useRecoilValue } from 'recoil'
 
 interface Props {
   id: string
 }
 const ActionGroupCardButton: FC<Props> = ({ id }) => {
   const actionGroup = useRecoilValue(actionGroupFamily(id))
-  const [loading, setLoading] = useState(false)
+  const [loading, onPostActionByActionGroupId] =
+    usePostActionByActionGroupId(id)
 
-  const onPost = useRecoilCallback(
-    // TODO: Write a hook with loading state
-    ({ set }) =>
-      async () => {
-        try {
-          setLoading(true)
-          const [data] = await postActionByActionGroupId(id)
-          set(actionGroupFamily(data.props.id), data)
-        } finally {
-          setLoading(false)
-        }
-      },
-    [id, setLoading],
-  )
-
+  // TODO:
   if (!actionGroup?.isOpened || actionGroup.isTodayHandled) return null
   if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
     return null
 
   return (
     <StyledCircularButtonAtom
-      onClick={onPost}
+      onClick={onPostActionByActionGroupId}
       radius={80}
       bgColor="green"
       title="Done!"

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -13,7 +13,7 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
   const [loading, onPostActionByActionGroupId] =
     usePostActionByActionGroupId(id)
 
-  // TODO:
+  // TODO: Must use the API given derived state of the action instead (once api does it)
   if (!actionGroup?.isOpened || actionGroup.isTodayHandled) return null
   if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
     return null

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -16,6 +16,7 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
     usePostActionByActionGroupId(id)
 
   const isOnClickCommitLateDisabled: boolean = useMemo(() => {
+    // TODO: Must use the API given derived state of the action instead (once api does it)
     if (!actionGroup) return true // disabled
     if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
       return true // disabled

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -1,0 +1,34 @@
+import { FC, useCallback } from 'react'
+import MoreIcon from '@mui/icons-material/MoreVert'
+import StyledIconButtonWithMenuAtom from '@/atoms/StyledIconButtonWithMenu'
+
+interface Props {
+  id: string // action group id
+  nickname?: string
+}
+const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
+  const isOnClickCommitLateDisabled = false // TODO: Implement this
+
+  const onClickCommitLate = useCallback(async () => {
+    console.log(`hello world!` + id)
+    // TODO: Implement this
+  }, [id])
+
+  if (nickname) return null // if it is shared mode (or has nickname), do not show the button
+
+  return (
+    <StyledIconButtonWithMenuAtom
+      menus={[
+        {
+          title: `Commit Late`,
+          isDisabled: isOnClickCommitLateDisabled,
+          onClick: onClickCommitLate,
+        },
+      ]}
+      jsxElementButton={<MoreIcon />}
+      onClick={onClickCommitLate}
+    />
+  )
+}
+
+export default ActionGroupCardMoreOptions

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -1,18 +1,28 @@
-import { FC, useCallback } from 'react'
+import { FC, useMemo } from 'react'
 import MoreIcon from '@mui/icons-material/MoreVert'
 import StyledIconButtonWithMenuAtom from '@/atoms/StyledIconButtonWithMenu'
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { useRecoilValue } from 'recoil'
+import { ActionGroupFixedId } from '@/constants/action-group.constant'
+import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
 
 interface Props {
   id: string // action group id
   nickname?: string
 }
 const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
-  const isOnClickCommitLateDisabled = false // TODO: Implement this
+  const actionGroup = useRecoilValue(actionGroupFamily(id))
+  const [loading, onPostActionByActionGroupId] =
+    usePostActionByActionGroupId(id)
 
-  const onClickCommitLate = useCallback(async () => {
-    console.log(`hello world!` + id)
-    // TODO: Implement this
-  }, [id])
+  const isOnClickCommitLateDisabled: boolean = useMemo(() => {
+    if (!actionGroup) return true // disabled
+    if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
+      return true // disabled
+    // if already handled:
+    if (actionGroup.isTodaySuccessful) return true // disabled
+    return !actionGroup.isPassed // disabled if it is not passed
+  }, [actionGroup])
 
   if (nickname) return null // if it is shared mode (or has nickname), do not show the button
 
@@ -20,13 +30,13 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
     <StyledIconButtonWithMenuAtom
       menus={[
         {
+          id: `commit_late`,
           title: `Commit Late`,
-          isDisabled: isOnClickCommitLateDisabled,
-          onClick: onClickCommitLate,
+          isDisabled: isOnClickCommitLateDisabled || loading,
+          onClick: onPostActionByActionGroupId,
         },
       ]}
       jsxElementButton={<MoreIcon />}
-      onClick={onClickCommitLate}
     />
   )
 }

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -6,6 +6,7 @@ import ActivityCalendarById from '../molecule_activity_calendar/index.by-id'
 import ActionGroupCardButton from './index.buttons'
 import ActionGroupCardTitle from './index.title'
 import ActionGroupCardSpecialMessage from './index.special-message'
+import ActionGroupCardMoreOptions from './index.more-options'
 
 interface Props {
   id: string
@@ -26,6 +27,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
           <ActionGroupCardTitle id={id} />
           <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
+          <ActionGroupCardMoreOptions id={id} nickname={nickname} />
         </Stack>
         <Stack alignItems="center">
           <ActivityCalendarById id={id} />

--- a/src/components/molecule_activity_calendar/index.by-id.tsx
+++ b/src/components/molecule_activity_calendar/index.by-id.tsx
@@ -34,6 +34,7 @@ const ActivityCalendarById: FC<Props> = ({ id }) => {
     return [sliceFrom, 365 - sliceFrom]
   }, [width])
 
+  // TODO: Must use the API given derived state of the action instead (once api does it)
   if (actionGroup === null) return <ActivityCalendarUnknown />
   if (actionGroup === undefined) return null
   if (

--- a/src/hooks/action-group/use-post-action-by-action-group-id.hook.ts
+++ b/src/hooks/action-group/use-post-action-by-action-group-id.hook.ts
@@ -1,0 +1,26 @@
+import { useRecoilCallback } from 'recoil'
+import { useState } from 'react'
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { postActionByActionGroupId } from '@/api/action-groups/post-action-by-action-group-id.api'
+
+type UsePostActionByActionGroupId = [boolean, () => Promise<void>]
+export const usePostActionByActionGroupId = (
+  actionGroupId: string,
+): UsePostActionByActionGroupId => {
+  const [loading, setLoading] = useState(false)
+
+  const onPostActionByActionGroupId = useRecoilCallback(
+    ({ set }) =>
+      async () => {
+        try {
+          setLoading(true)
+          const [data] = await postActionByActionGroupId(actionGroupId)
+          set(actionGroupFamily(data.props.id), data)
+        } finally {
+          setLoading(false)
+        }
+      },
+    [actionGroupId, setLoading],
+  )
+  return [loading, onPostActionByActionGroupId]
+}

--- a/src/hooks/action-group/use-post-action-by-action-group-id.hook.ts
+++ b/src/hooks/action-group/use-post-action-by-action-group-id.hook.ts
@@ -1,7 +1,7 @@
 import { useRecoilCallback } from 'recoil'
 import { useState } from 'react'
 import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
-import { postActionByActionGroupId } from '@/api/action-groups/post-action-by-action-group-id.api'
+import { postActionByActionGroupIdApi } from '@/api/action-groups/post-action-by-action-group-id.api'
 
 type UsePostActionByActionGroupId = [boolean, () => Promise<void>]
 export const usePostActionByActionGroupId = (
@@ -14,7 +14,7 @@ export const usePostActionByActionGroupId = (
       async () => {
         try {
           setLoading(true)
-          const [data] = await postActionByActionGroupId(actionGroupId)
+          const [data] = await postActionByActionGroupIdApi(actionGroupId)
           set(actionGroupFamily(data.props.id), data)
         } finally {
           setLoading(false)


### PR DESCRIPTION
# Background
Action should be committable even when it is late.
Actually the API does allow it, but the level is still set to 4,
but this is not a problem as the API will eventually return a different level for the late commitment anyway.

## TODOs
- [x] Implement a late commit button
- [x] The late commit button must be disabled, if it is not late yet

## Checklist (Developers)
- [x] `Draft` is set for this PR
- [x] `Title` is checked
- [x] `Background` is filled
- [x] `TODOs` are filled
- [x] `Assignee` is set
- [x] `Labels` are set
- [x] `development` is linked if related issue exists
- [x] `yarn inspect` is run
- [x] `TODOs` are handled and checked
- [x] Final Operation Check is done
- [x] Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
