### PR TITLE
Delete Today's action

### DIFF
--- a/src/api/action-groups/delete-today-actions-by-action-group-id.api.ts
+++ b/src/api/action-groups/delete-today-actions-by-action-group-id.api.ts
@@ -1,0 +1,15 @@
+import axios from 'axios'
+import { CustomizedAxiosResponse } from '../index.interface'
+import { GetActionGroupRes } from './index.interface'
+
+/**
+ * Delete Today's actions by action group id
+ * this will delete EVERY today's action.
+ */
+export const deleteTodayActionsByActionGroupId = async (
+  actionGroupId: string,
+): Promise<CustomizedAxiosResponse<GetActionGroupRes>> => {
+  const url = `/v1/action-groups/${actionGroupId}/actions/today`
+  const res = await axios.delete(url)
+  return [res.data, res]
+}

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -5,6 +5,7 @@ import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
 import { useRecoilValue } from 'recoil'
 import { ActionGroupFixedId } from '@/constants/action-group.constant'
 import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
+import { useDeleteTodayActionsByActionGroupId } from '@/hooks/action-group/use-delete-today-actions-by-action-group-id.hook'
 
 interface Props {
   id: string // action group id
@@ -12,8 +13,10 @@ interface Props {
 }
 const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
   const actionGroup = useRecoilValue(actionGroupFamily(id))
-  const [loading, onPostActionByActionGroupId] =
+  const [loadingLatePost, onPostActionByActionGroupId] =
     usePostActionByActionGroupId(id)
+  const [loadingDelete, onDeleteTodayActionsByActionGroupId] =
+    useDeleteTodayActionsByActionGroupId(id)
 
   const isOnClickCommitLateDisabled: boolean = useMemo(() => {
     // TODO: Must use the API given derived state of the action instead (once api does it)
@@ -25,6 +28,17 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
     return !actionGroup.isPassed // disabled if it is not passed
   }, [actionGroup])
 
+  const isDeleteTodayActionsDisabled: boolean = useMemo(() => {
+    // TODO: Must use the API given derived state of the action instead (once api does it)
+    if (!actionGroup) return true // disabled
+    if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
+      return true // disabled
+    return !actionGroup.isTodaySuccessful // disabled if it is not successful
+  }, [actionGroup])
+
+  // contains every loading state of a function:
+  const everyLoading = loadingLatePost || loadingDelete
+
   if (nickname) return null // if it is shared mode (or has nickname), do not show the button
 
   return (
@@ -33,8 +47,14 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
         {
           id: `commit_late`,
           title: `Commit Late`,
-          isDisabled: isOnClickCommitLateDisabled || loading,
+          isDisabled: isOnClickCommitLateDisabled || everyLoading,
           onClick: onPostActionByActionGroupId,
+        },
+        {
+          id: `delete_today_actions`,
+          title: `Delete Today's Action`, // not actions (has "s") because API only allows one action per day atm in Mar 2024
+          isDisabled: isDeleteTodayActionsDisabled || everyLoading,
+          onClick: onDeleteTodayActionsByActionGroupId,
         },
       ]}
       jsxElementButton={<MoreIcon />}

--- a/src/hooks/action-group/use-delete-today-actions-by-action-group-id.hook.ts
+++ b/src/hooks/action-group/use-delete-today-actions-by-action-group-id.hook.ts
@@ -1,0 +1,26 @@
+import { useRecoilCallback } from 'recoil'
+import { useState } from 'react'
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { deleteTodayActionsByActionGroupId } from '@/api/action-groups/delete-today-actions-by-action-group-id.api'
+
+type UsePostActionByActionGroupId = [boolean, () => Promise<void>]
+export const useDeleteTodayActionsByActionGroupId = (
+  actionGroupId: string,
+): UsePostActionByActionGroupId => {
+  const [loading, setLoading] = useState(false)
+
+  const onDeleteTodayActionsByActionGroupId = useRecoilCallback(
+    ({ set }) =>
+      async () => {
+        try {
+          setLoading(true)
+          const [data] = await deleteTodayActionsByActionGroupId(actionGroupId)
+          set(actionGroupFamily(data.props.id), data)
+        } finally {
+          setLoading(false)
+        }
+      },
+    [actionGroupId, setLoading],
+  )
+  return [loading, onDeleteTodayActionsByActionGroupId]
+}


### PR DESCRIPTION
# Background
You can now delete accidentally created actions
![image](https://github.com/ajktown/ConsistencyGPT/assets/53258958/b533b05a-f46a-45fe-8694-6b6b83668787)

## TODOs
- [x] Implement a button to delete today's action(s)

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
