### PR TITLE
Order changable

### DIFF
--- a/src/api/preferences/index.interface.ts
+++ b/src/api/preferences/index.interface.ts
@@ -8,4 +8,5 @@ export interface IPreference extends DataBasics {
 
 export interface PreferenceModifiable {
   nativeLanguages: GlobalLanguageCode[]
+  selectedDictIds: string[]
 }

--- a/src/api/rituals/get-rituals.api.ts
+++ b/src/api/rituals/get-rituals.api.ts
@@ -1,15 +1,19 @@
 import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 
-export interface IRitual {
+interface IRitual {
   id: string
   ownerId: string
   name: string
-  orderedActionGroupIds: string[]
+  // orderedActionGroupIds: string[] // don't need it so its commented out
+}
+
+export interface IParentRitual extends IRitual {
+  actionGroupIds: string[]
 }
 
 export interface GetRitualsRes {
-  rituals: IRitual[]
+  rituals: IParentRitual[]
 }
 
 /**

--- a/src/api/rituals/get-rituals.api.ts
+++ b/src/api/rituals/get-rituals.api.ts
@@ -5,7 +5,6 @@ export interface IRitual {
   id: string
   ownerId: string
   name: string
-  actionGroupIds: string[]
   orderedActionGroupIds: string[]
 }
 

--- a/src/api/rituals/get-rituals.api.ts
+++ b/src/api/rituals/get-rituals.api.ts
@@ -1,11 +1,11 @@
 import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 
-interface IRitual {
+export interface IRitual {
   id: string
   ownerId: string
   name: string
-  actionGroupIds: string[]
+  orderedActionGroupIds: string[]
 }
 
 export interface GetRitualsRes {

--- a/src/api/rituals/get-rituals.api.ts
+++ b/src/api/rituals/get-rituals.api.ts
@@ -5,6 +5,7 @@ export interface IRitual {
   id: string
   ownerId: string
   name: string
+  actionGroupIds: string[]
   orderedActionGroupIds: string[]
 }
 

--- a/src/api/rituals/patch-ritual.api.ts
+++ b/src/api/rituals/patch-ritual.api.ts
@@ -1,13 +1,13 @@
 import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
-import { IRitual } from './get-rituals.api'
+import { IParentRitual } from './get-rituals.api'
 
 export interface PatchRitualGroupBodyDTO {
   actionGroupIds: string[]
 }
 
 export interface GetRitualByIdRes {
-  ritual: IRitual
+  ritual: IParentRitual
 }
 
 export const patchRitualApi = async (

--- a/src/api/rituals/patch-ritual.api.ts
+++ b/src/api/rituals/patch-ritual.api.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+import { CustomizedAxiosResponse } from '../index.interface'
+import { IRitual } from './get-rituals.api'
+
+export interface PatchRitualGroupBodyDTO {
+  actionGroupIds: string[]
+}
+
+export interface GetRitualByIdRes {
+  ritual: IRitual
+}
+
+export const patchRitualApi = async (
+  dto: Partial<PatchRitualGroupBodyDTO>,
+): Promise<CustomizedAxiosResponse<GetRitualByIdRes>> => {
+  const url = `/v1/rituals/default`
+  const res = await axios.patch(url, dto)
+  return [res.data, res]
+}

--- a/src/components/atom_user_avatar/index.end-user.tsx
+++ b/src/components/atom_user_avatar/index.end-user.tsx
@@ -1,5 +1,6 @@
 import { PropsMenuItem } from '@/atoms/StyledIconButtonWithMenu'
 import StyledUserAvatar from '@/atoms/StyledUserAvatar'
+import { PageConst } from '@/constants/pages.constant'
 import { useOnSignOutApp } from '@/hooks/app/use-on-sign-out-app.hook'
 import { authPrepState } from '@/recoil/app/app.state'
 import { useRouter } from 'next/router'
@@ -15,6 +16,9 @@ const EndUserAvatar: FC = () => {
   const onSignOutApp = useOnSignOutApp()
   const onClickToAdminProfile = useCallback(() => {
     router.push(`/users/mlajkim`)
+  }, [router])
+  const onClickToSetting = useCallback(() => {
+    router.push(PageConst.Setting)
   }, [router])
   const onClickBuyMeCoffee = useCallback(() => {
     const url = `https://www.buymeacoffee.com/mlajkim`
@@ -32,6 +36,11 @@ const EndUserAvatar: FC = () => {
         id: `to_mlajkim_profile`,
         title: `To mlajkim's profile`,
         onClick: onClickToAdminProfile,
+      },
+      {
+        id: `setting`,
+        title: `Setting`,
+        onClick: onClickToSetting,
       },
       {
         id: `sign_out`,

--- a/src/components/molecule_action_group_card/index.modifying-order.tsx
+++ b/src/components/molecule_action_group_card/index.modifying-order.tsx
@@ -1,0 +1,31 @@
+import { FC, useCallback } from 'react'
+import { Card, Stack } from '@mui/material'
+import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
+import { useActionGroupById } from '@/hooks/action-group/use-action-group-by-id.hook'
+import ActionGroupCardTitle from './index.title'
+
+interface Props {
+  id: string
+}
+const ActionGroupCardModifyingOrder: FC<Props> = ({ id }) => {
+  const onGetActionGroupById = useActionGroupById(id)
+
+  const onClickRefresh = useCallback(async () => {
+    // run all together
+    await Promise.all([onGetActionGroupById()])
+  }, [onGetActionGroupById])
+
+  return (
+    <Card>
+      <Stack m={3}>
+        {/* Header */}
+        <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
+          <ActionGroupCardTitle id={id} />
+          <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
+        </Stack>
+      </Stack>
+    </Card>
+  )
+}
+
+export default ActionGroupCardModifyingOrder

--- a/src/components/molecule_action_group_card/index.modifying-order.tsx
+++ b/src/components/molecule_action_group_card/index.modifying-order.tsx
@@ -1,8 +1,11 @@
 import { FC, useCallback } from 'react'
-import { Card, Stack } from '@mui/material'
+import { ListItem, ListItemText, Stack } from '@mui/material'
 import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
 import { useActionGroupById } from '@/hooks/action-group/use-action-group-by-id.hook'
 import ActionGroupCardTitle from './index.title'
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
 
 interface Props {
   id: string
@@ -16,15 +19,18 @@ const ActionGroupCardModifyingOrder: FC<Props> = ({ id }) => {
   }, [onGetActionGroupById])
 
   return (
-    <Card>
-      <Stack m={3}>
-        {/* Header */}
-        <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
-          <ActionGroupCardTitle id={id} />
+    <ListItem
+      disableGutters
+      secondaryAction={
+        <Stack alignItems={'center'} direction="row">
           <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
+          <StyledIconButtonAtom jsxElementButton={<ArrowUpwardIcon />} />
+          <StyledIconButtonAtom jsxElementButton={<ArrowDownwardIcon />} />
         </Stack>
-      </Stack>
-    </Card>
+      }
+    >
+      <ListItemText primary={<ActionGroupCardTitle id={id} />} />
+    </ListItem>
   )
 }
 

--- a/src/components/organism_setting_frame/index.setting-refresher.tsx
+++ b/src/components/organism_setting_frame/index.setting-refresher.tsx
@@ -1,0 +1,19 @@
+import { FC, useCallback } from 'react'
+import { useActionGroupById } from '@/hooks/action-group/use-action-group-by-id.hook'
+import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
+
+interface Props {
+  groupId: string
+}
+const SettingFrameRefresher: FC<Props> = ({ groupId }) => {
+  const onGetActionGroupById = useActionGroupById(groupId)
+
+  const onClickRefresh = useCallback(async () => {
+    // run all together
+    await Promise.all([onGetActionGroupById()])
+  }, [onGetActionGroupById])
+
+  return <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
+}
+
+export default SettingFrameRefresher

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -8,11 +8,19 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
 import ActionGroupCardTitle from '../molecule_action_group_card/index.title'
 import { usePatchRitual } from '@/hooks/ritual/use-patch-ritual.hook'
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import { useRouter } from 'next/router'
+import { PageConst } from '@/constants/pages.constant'
 
 const SettingFrame: FC = () => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
   const onPatchRitual = usePatchRitual()
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
+  const router = useRouter()
+
+  const onClickToHomePage = useCallback(() => {
+    router.push(PageConst.Home)
+  }, [router])
 
   const onClickArrow = useCallback(
     async (id: string, isUpward = true) => {
@@ -30,7 +38,7 @@ const SettingFrame: FC = () => {
 
         // highlight modified action group so that it is  easier to track:
         setHighlightedId(id)
-        setTimeout(() => setHighlightedId(null), 1 * 1000) // 1 second
+        setTimeout(() => setHighlightedId(null), 0.4 * 1000) // seconds
       } catch {}
     },
     [actionGroupIds, onPatchRitual],
@@ -38,6 +46,10 @@ const SettingFrame: FC = () => {
 
   return (
     <Stack alignItems={`center`} spacing={2} p={2}>
+      <StyledTextButtonAtom
+        title={`Back to main page`}
+        onClick={onClickToHomePage}
+      />
       <List sx={{ width: '100%', maxWidth: 700, bgcolor: 'background.paper' }}>
         {actionGroupIds.map((id, i) => (
           <ListItem

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
+import { useRecoilValue } from 'recoil'
+import { Stack } from '@mui/material'
+import ActionGroupCardModifyingOrder from '../molecule_action_group_card/index.modifying-order'
+
+const SettingFrame: FC = () => {
+  const actionGroupIds = useRecoilValue(actionGroupIdsState)
+
+  return (
+    <Stack alignItems={`center`} spacing={2} p={2}>
+      {actionGroupIds.map((id) => (
+        <ActionGroupCardModifyingOrder key={id} id={id} />
+      ))}
+    </Stack>
+  )
+}
+
+export default SettingFrame

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -13,17 +13,18 @@ const SettingFrame: FC = () => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
   const onPatchRitual = usePatchRitual()
 
-  const onClickUp = useCallback(
-    async (id: string) => {
+  const onClickArrow = useCallback(
+    async (id: string, isUpward = true) => {
       try {
         const index = actionGroupIds.findIndex(
           (actionGroupId) => actionGroupId === id,
         )
         const newActionGroupIds = [...actionGroupIds]
         const tmp = newActionGroupIds[index]
-        newActionGroupIds[index] = newActionGroupIds[index - 1]
-        newActionGroupIds[index - 1] = tmp
-        console.log({ newActionGroupIds })
+
+        const newIndex = isUpward ? -1 : 1
+        newActionGroupIds[index] = newActionGroupIds[index + newIndex]
+        newActionGroupIds[index + newIndex] = tmp
         await onPatchRitual({ actionGroupIds: newActionGroupIds })
       } catch {}
     },
@@ -33,7 +34,7 @@ const SettingFrame: FC = () => {
   return (
     <Stack alignItems={`center`} spacing={2} p={2}>
       <List sx={{ width: '100%', maxWidth: 700, bgcolor: 'background.paper' }}>
-        {actionGroupIds.map((id) => (
+        {actionGroupIds.map((id, i) => (
           <ListItem
             key={id}
             disableGutters
@@ -42,10 +43,13 @@ const SettingFrame: FC = () => {
                 <SettingFrameRefresher groupId={id} />
                 <StyledIconButtonAtom
                   jsxElementButton={<ArrowUpwardIcon />}
-                  onClick={() => onClickUp(id)}
+                  onClick={() => onClickArrow(id)}
+                  isDisabled={i === 0}
                 />
                 <StyledIconButtonAtom
                   jsxElementButton={<ArrowDownwardIcon />}
+                  onClick={() => onClickArrow(id, false)}
+                  isDisabled={i === actionGroupIds.length - 1}
                 />
               </Stack>
             }

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
 import { useRecoilValue } from 'recoil'
-import { Stack } from '@mui/material'
+import { List, Stack } from '@mui/material'
 import ActionGroupCardModifyingOrder from '../molecule_action_group_card/index.modifying-order'
 
 const SettingFrame: FC = () => {
@@ -9,9 +9,11 @@ const SettingFrame: FC = () => {
 
   return (
     <Stack alignItems={`center`} spacing={2} p={2}>
-      {actionGroupIds.map((id) => (
-        <ActionGroupCardModifyingOrder key={id} id={id} />
-      ))}
+      <List sx={{ width: '100%', maxWidth: 700, bgcolor: 'background.paper' }}>
+        {actionGroupIds.map((id) => (
+          <ActionGroupCardModifyingOrder key={id} id={id} />
+        ))}
+      </List>
     </Stack>
   )
 }

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,17 +1,57 @@
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
 import { useRecoilValue } from 'recoil'
-import { List, Stack } from '@mui/material'
-import ActionGroupCardModifyingOrder from '../molecule_action_group_card/index.modifying-order'
+import { List, ListItem, ListItemText, Stack } from '@mui/material'
+import SettingFrameRefresher from './index.setting-refresher'
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
+import ActionGroupCardTitle from '../molecule_action_group_card/index.title'
+import { usePatchRitual } from '@/hooks/ritual/use-patch-ritual.hook'
 
 const SettingFrame: FC = () => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
+  const onPatchRitual = usePatchRitual()
+
+  const onClickUp = useCallback(
+    async (id: string) => {
+      try {
+        const index = actionGroupIds.findIndex(
+          (actionGroupId) => actionGroupId === id,
+        )
+        const newActionGroupIds = [...actionGroupIds]
+        const tmp = newActionGroupIds[index]
+        newActionGroupIds[index] = newActionGroupIds[index - 1]
+        newActionGroupIds[index - 1] = tmp
+        console.log({ newActionGroupIds })
+        await onPatchRitual({ actionGroupIds: newActionGroupIds })
+      } catch {}
+    },
+    [actionGroupIds, onPatchRitual],
+  )
 
   return (
     <Stack alignItems={`center`} spacing={2} p={2}>
       <List sx={{ width: '100%', maxWidth: 700, bgcolor: 'background.paper' }}>
         {actionGroupIds.map((id) => (
-          <ActionGroupCardModifyingOrder key={id} id={id} />
+          <ListItem
+            key={id}
+            disableGutters
+            secondaryAction={
+              <Stack alignItems={'center'} direction="row">
+                <SettingFrameRefresher groupId={id} />
+                <StyledIconButtonAtom
+                  jsxElementButton={<ArrowUpwardIcon />}
+                  onClick={() => onClickUp(id)}
+                />
+                <StyledIconButtonAtom
+                  jsxElementButton={<ArrowDownwardIcon />}
+                />
+              </Stack>
+            }
+          >
+            <ListItemText primary={<ActionGroupCardTitle id={id} />} />
+          </ListItem>
         ))}
       </List>
     </Stack>

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react'
+import { FC, useCallback, useState } from 'react'
 import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
 import { useRecoilValue } from 'recoil'
 import { List, ListItem, ListItemText, Stack } from '@mui/material'
@@ -12,6 +12,7 @@ import { usePatchRitual } from '@/hooks/ritual/use-patch-ritual.hook'
 const SettingFrame: FC = () => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
   const onPatchRitual = usePatchRitual()
+  const [highlightedId, setHighlightedId] = useState<string | null>(null)
 
   const onClickArrow = useCallback(
     async (id: string, isUpward = true) => {
@@ -26,6 +27,10 @@ const SettingFrame: FC = () => {
         newActionGroupIds[index] = newActionGroupIds[index + newIndex]
         newActionGroupIds[index + newIndex] = tmp
         await onPatchRitual({ actionGroupIds: newActionGroupIds })
+
+        // highlight modified action group so that it is  easier to track:
+        setHighlightedId(id)
+        setTimeout(() => setHighlightedId(null), 1 * 1000) // 1 second
       } catch {}
     },
     [actionGroupIds, onPatchRitual],
@@ -38,6 +43,7 @@ const SettingFrame: FC = () => {
           <ListItem
             key={id}
             disableGutters
+            sx={{ bgcolor: highlightedId === id ? 'lightyellow' : 'inherit' }}
             secondaryAction={
               <Stack alignItems={'center'} direction="row">
                 <SettingFrameRefresher groupId={id} />

--- a/src/constants/pages.constant.ts
+++ b/src/constants/pages.constant.ts
@@ -4,6 +4,7 @@ export enum PageConst {
   Users = `/users`,
   SignIn = `/signin`,
   SignUp = `/signup`,
+  Setting = `/setting`,
 }
 
 export const DEFAULT_MAIN_APP_PAGE: PageConst = PageConst.Home

--- a/src/hooks/app/use-is-app-booted.hook.ts
+++ b/src/hooks/app/use-is-app-booted.hook.ts
@@ -16,8 +16,9 @@ export const useIsAppBooted = (): boolean => {
     try {
       const isSignedIn = (await onGetAuthPrep())?.isSignedIn
 
-      // if starts with user, dont do anything
+      // The following page does not need to be redirected.
       if (router.asPath.startsWith(PageConst.Users)) return
+      if (router.asPath.startsWith(PageConst.Setting)) return
 
       // If user is not signed in at this point, it should be an error.
       if (!isSignedIn) throw new Error(`Not Signed In`)

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -11,8 +11,7 @@ export const usePatchRitual = () => {
       async (dto: Partial<PatchRitualGroupBodyDTO>) => {
         try {
           const [data] = await patchRitualApi(dto)
-          console.log(data)
-          set(actionGroupIdsState, data.ritual.actionGroupIds)
+          set(actionGroupIdsState, data.ritual.orderedActionGroupIds)
         } catch {}
       },
     [],

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -1,0 +1,22 @@
+import { useRecoilCallback } from 'recoil'
+import {
+  PatchRitualGroupBodyDTO,
+  patchRitualApi,
+} from '@/api/rituals/patch-ritual.api'
+import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
+
+export const usePatchRitual = () => {
+  const onPatchRitual = useRecoilCallback(
+    ({ set }) =>
+      async (dto: Partial<PatchRitualGroupBodyDTO>) => {
+        try {
+          const [data] = await patchRitualApi(dto)
+          console.log(data)
+          set(actionGroupIdsState, data.ritual.orderedActionGroupIds)
+        } catch {}
+      },
+    [],
+  )
+
+  return onPatchRitual
+}

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -11,7 +11,8 @@ export const usePatchRitual = () => {
       async (dto: Partial<PatchRitualGroupBodyDTO>) => {
         try {
           const [data] = await patchRitualApi(dto)
-          set(actionGroupIdsState, data.ritual.orderedActionGroupIds)
+          console.log(data)
+          set(actionGroupIdsState, data.ritual.actionGroupIds)
         } catch {}
       },
     [],

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -11,7 +11,6 @@ export const usePatchRitual = () => {
       async (dto: Partial<PatchRitualGroupBodyDTO>) => {
         try {
           const [data] = await patchRitualApi(dto)
-          console.log(data)
           set(actionGroupIdsState, data.ritual.actionGroupIds)
         } catch {}
       },

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -12,7 +12,7 @@ export const usePatchRitual = () => {
         try {
           const [data] = await patchRitualApi(dto)
           console.log(data)
-          set(actionGroupIdsState, data.ritual.orderedActionGroupIds)
+          set(actionGroupIdsState, data.ritual.actionGroupIds)
         } catch {}
       },
     [],

--- a/src/hooks/ritual/use-rituals.hook.ts
+++ b/src/hooks/ritual/use-rituals.hook.ts
@@ -18,7 +18,7 @@ export const useRituals = () => {
 
           if (!res || res.rituals.length === 0) return
 
-          set(actionGroupIdsState, res.rituals[0].actionGroupIds)
+          set(actionGroupIdsState, res.rituals[0].orderedActionGroupIds)
         } catch {
           set(actionGroupIdsState, [])
         }

--- a/src/hooks/ritual/use-rituals.hook.ts
+++ b/src/hooks/ritual/use-rituals.hook.ts
@@ -18,7 +18,7 @@ export const useRituals = () => {
 
           if (!res || res.rituals.length === 0) return
 
-          set(actionGroupIdsState, res.rituals[0].orderedActionGroupIds)
+          set(actionGroupIdsState, res.rituals[0].actionGroupIds)
         } catch {
           set(actionGroupIdsState, [])
         }

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react'
+import Appbar from '@/components/organism_appbar'
+import SettingFrame from '@/components/organism_setting_frame'
+
+const SettingPage: FC = () => {
+  return (
+    <Appbar>
+      <SettingFrame />
+    </Appbar>
+  )
+}
+
+export default SettingPage


### PR DESCRIPTION
# Background
Users can now modify `Action Groups`'s order as the following:
![image](https://github.com/ajktown/ConsistencyGPT/assets/53258958/e69af7ae-841e-477f-bed2-bee2362f7532)

## TODOs
- [x] Utilize `PATCH /api/v1/rituals/domain` to modify the `action-group-ids`

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
