### PR TITLE
Early not committed feature

### DIFF
--- a/src/api/action-groups/post-action-by-action-group-id.api.ts
+++ b/src/api/action-groups/post-action-by-action-group-id.api.ts
@@ -2,10 +2,15 @@ import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 import { GetActionGroupRes } from './index.interface'
 
+export interface PostActionBodyDTO {
+  isDummy: boolean
+}
+
 export const postActionByActionGroupIdApi = async (
   actionGroupId: string,
+  dto: undefined | PostActionBodyDTO,
 ): Promise<CustomizedAxiosResponse<GetActionGroupRes>> => {
   const url = `/v1/action-groups/${actionGroupId}/actions`
-  const res = await axios.post(url)
+  const res = await axios.post(url, dto)
   return [res.data, res]
 }

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -14,9 +14,10 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
     usePostActionByActionGroupId(id)
 
   if (!actionGroup) return null
-  if (actionGroup.derivedState.isOnTimeCommittable) return null
   if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
     return null
+  if (!actionGroup.derivedState.isOnTimeCommittable) return null
+
 
   return (
     <StyledCircularButtonAtom

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -18,7 +18,6 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
     return null
   if (!actionGroup.derivedState.isOnTimeCommittable) return null
 
-
   return (
     <StyledCircularButtonAtom
       onClick={onPostActionByActionGroupId}

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil'
 import { ActionGroupFixedId } from '@/constants/action-group.constant'
 import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
 import { useDeleteTodayActionsByActionGroupId } from '@/hooks/action-group/use-delete-today-actions-by-action-group-id.hook'
+import { usePostDummyActionByActionGroupId } from '@/hooks/action-group/use-post-dummy-action-by-action-group-id.hook'
 
 interface Props {
   id: string // action group id
@@ -17,6 +18,8 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
     usePostActionByActionGroupId(id)
   const [loadingDelete, onDeleteTodayActionsByActionGroupId] =
     useDeleteTodayActionsByActionGroupId(id)
+  const [loadingDummyPost, onPostDummyActionByActionGroupId] =
+    usePostDummyActionByActionGroupId(id)
 
   const isOnClickCommitLateDisabled: boolean = useMemo(() => {
     if (!actionGroup) return true // disabled
@@ -25,6 +28,15 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
 
     // if already handled:
     return !actionGroup.derivedState.isLateCommittable
+  }, [actionGroup])
+
+  const isDummyCommittableDisabled: boolean = useMemo(() => {
+    if (!actionGroup) return true // disabled
+    if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
+      return true // disabled
+
+    // if already handled:
+    return !actionGroup.derivedState.isDummyCommittable
   }, [actionGroup])
 
   const isDeleteTodayActionsDisabled: boolean = useMemo(() => {
@@ -36,13 +48,19 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
   }, [actionGroup])
 
   // contains every loading state of a function:
-  const everyLoading = loadingLatePost || loadingDelete
+  const everyLoading = loadingLatePost || loadingDelete || loadingDummyPost
 
   if (nickname) return null // if it is shared mode (or has nickname), do not show the button
 
   return (
     <StyledIconButtonWithMenuAtom
       menus={[
+        {
+          id: `today_not_committable`,
+          title: `Today Not Committable`,
+          isDisabled: isDummyCommittableDisabled || everyLoading,
+          onClick: onPostDummyActionByActionGroupId,
+        },
         {
           id: `commit_late`,
           title: `Commit Late`,

--- a/src/components/molecule_activity_calendar/index.by-id.tsx
+++ b/src/components/molecule_activity_calendar/index.by-id.tsx
@@ -36,11 +36,7 @@ const ActivityCalendarById: FC<Props> = ({ id }) => {
 
   if (actionGroup === null) return <ActivityCalendarUnknown />
   if (actionGroup === undefined) return null
-  if (
-    !actionGroup.derivedState.isOnTimeCommittable &&
-    actionGroup.props.id !== ActionGroupFixedId.DailyPostWordChallenge
-  )
-    return null
+  if (actionGroup.props.id !== ActionGroupFixedId.DailyPostWordChallenge && actionGroup.derivedState.isOnTimeCommittable) return null
 
   return (
     <ReactActivityCalendar

--- a/src/components/molecule_activity_calendar/index.by-id.tsx
+++ b/src/components/molecule_activity_calendar/index.by-id.tsx
@@ -36,7 +36,11 @@ const ActivityCalendarById: FC<Props> = ({ id }) => {
 
   if (actionGroup === null) return <ActivityCalendarUnknown />
   if (actionGroup === undefined) return null
-  if (actionGroup.props.id !== ActionGroupFixedId.DailyPostWordChallenge && actionGroup.derivedState.isOnTimeCommittable) return null
+  if (
+    actionGroup.props.id !== ActionGroupFixedId.DailyPostWordChallenge &&
+    actionGroup.derivedState.isOnTimeCommittable
+  )
+    return null
 
   return (
     <ReactActivityCalendar

--- a/src/hooks/action-group/use-post-dummy-action-by-action-group-id.hook.ts
+++ b/src/hooks/action-group/use-post-dummy-action-by-action-group-id.hook.ts
@@ -3,21 +3,20 @@ import { useState } from 'react'
 import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
 import { postActionByActionGroupIdApi } from '@/api/action-groups/post-action-by-action-group-id.api'
 
-type UsePostActionByActionGroupId = [boolean, () => Promise<void>]
-export const usePostActionByActionGroupId = (
+type UsePostDummyActionByActionGroupId = [boolean, () => Promise<void>]
+export const usePostDummyActionByActionGroupId = (
   actionGroupId: string,
-): UsePostActionByActionGroupId => {
+): UsePostDummyActionByActionGroupId => {
   const [loading, setLoading] = useState(false)
 
-  const onPostActionByActionGroupId = useRecoilCallback(
+  const onPostDummyActionByActionGroupId = useRecoilCallback(
     ({ set }) =>
       async () => {
         try {
           setLoading(true)
-          const [data] = await postActionByActionGroupIdApi(
-            actionGroupId,
-            undefined,
-          )
+          const [data] = await postActionByActionGroupIdApi(actionGroupId, {
+            isDummy: true,
+          })
           set(actionGroupFamily(data.props.id), data)
         } finally {
           setLoading(false)
@@ -25,5 +24,5 @@ export const usePostActionByActionGroupId = (
       },
     [actionGroupId, setLoading],
   )
-  return [loading, onPostActionByActionGroupId]
+  return [loading, onPostDummyActionByActionGroupId]
 }


### PR DESCRIPTION
# Background
You can now early commit that you cannot perform certain action-group:
![image](https://github.com/ajktown/ConsistencyGPT/assets/53258958/62ac473c-6a2c-4619-8da9-80daefa35b92)

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
