### PR TITLE
Fix wrongful messaged when dummy committed on time 

### DIFF
--- a/src/components/molecule_action_group_card/index.special-message.tsx
+++ b/src/components/molecule_action_group_card/index.special-message.tsx
@@ -18,9 +18,13 @@ const ActionGroupCardSpecialMessage: FC<Props> = ({ id }) => {
   const onOpenNewTab = useOpenNewTab(url)
 
   if (!actionGroup) return null
-  if (actionGroup.isTodaySuccessful === null) return null
 
-  if (actionGroup.isTodayHandled)
+  // TODO: API must return isTodayAccomplished
+  if (
+    [`EarlyCommitted`, `OnTimeCommitted`, `LateCommitted`].includes(
+      actionGroup.state,
+    )
+  )
     return (
       <StyledTextWithHeaderIcon
         headerIcon={<CheckCircleOutlineIcon color="success" />}
@@ -30,26 +34,39 @@ const ActionGroupCardSpecialMessage: FC<Props> = ({ id }) => {
         title={`You've accomplished the task for today. Keep up the good work!`}
       />
     )
-
-  return (
-    <Stack mt={1}>
-      <StyledTextWithHeaderIcon
-        headerIcon={<WarningIcon color="warning" />}
-        textProps={{
-          fontFamily: `Cormorant Garamond`,
-        }}
-        title={`It seems like you've missed the task for today. Remember, consistency is the key in your success.`}
-      />
-      {actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge && (
-        <Fragment>
-          <Typography fontFamily={`Cormorant Garamond`}>
-            {`Please go visit ${url} and add a word for today.`}
-          </Typography>
-          <StyledTextButtonAtom title={`Visit ${url}`} onClick={onOpenNewTab} />
-        </Fragment>
-      )}
-    </Stack>
+  // TODO: API must return isTodayMissed
+  if (
+    [
+      `EarlyDummyCommitted`,
+      `OnTimeDummyCommitted`,
+      `LateDummyCommitted`,
+      `LateNotCommitted`,
+    ].includes(actionGroup.state)
   )
+    return (
+      <Stack mt={1}>
+        <StyledTextWithHeaderIcon
+          headerIcon={<WarningIcon color="warning" />}
+          textProps={{
+            fontFamily: `Cormorant Garamond`,
+          }}
+          title={`It seems like you've missed the task for today. Remember, consistency is the key in your success.`}
+        />
+        {actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge && (
+          <Fragment>
+            <Typography fontFamily={`Cormorant Garamond`}>
+              {`Please go visit ${url} and add a word for today.`}
+            </Typography>
+            <StyledTextButtonAtom
+              title={`Visit ${url}`}
+              onClick={onOpenNewTab}
+            />
+          </Fragment>
+        )}
+      </Stack>
+    )
+
+  return null
 }
 
 export default ActionGroupCardSpecialMessage


### PR DESCRIPTION
# Background
It says user has accomplished when dummy is committed for the day:
![image](https://github.com/ajktown/ConsistencyGPT/assets/53258958/fe92ddb6-1fa7-4f3a-b106-697150070a1a)


## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
