### PR TITLE
Use Patch Instead

### DIFF
--- a/src/api/preferences/patch-preference.api.ts
+++ b/src/api/preferences/patch-preference.api.ts
@@ -2,10 +2,10 @@ import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
 import { IPreference, PreferenceModifiable } from './index.interface'
 
-export const putPreferenceApi = async (
+export const patchPreferenceApi = async (
   modifying: Partial<PreferenceModifiable>,
 ): Promise<CustomizedAxiosResponse<IPreference>> => {
   const url = `/v1/preference`
-  const res = await axios.put(url, modifying)
+  const res = await axios.patch(url, modifying)
   return [res.data, res]
 }

--- a/src/hooks/preference/use-patch-preference-native-language.hook.ts
+++ b/src/hooks/preference/use-patch-preference-native-language.hook.ts
@@ -1,13 +1,13 @@
 import { useRecoilCallback } from 'recoil'
 import { preferenceState } from '@/recoil/preferences/preference.state'
 import { GlobalLanguageCode } from '@/global.interface'
-import { usePutPreference } from './use-put-preference.hook'
+import { usePatchPreference } from './use-patch-preference.hook'
 
-export const usePutPreferenceNativeLanguage = (
+export const usePatchPreferenceNativeLanguage = (
   languageCode: GlobalLanguageCode,
 ) => {
-  const onUsePutPreference = usePutPreference()
-  const onPutPreferenceNativeLanguage = useRecoilCallback(
+  const onPatchPreference = usePatchPreference()
+  const onPatchPreferenceNativeLanguage = useRecoilCallback(
     ({ snapshot }) =>
       async (_, checked: boolean) => {
         try {
@@ -23,11 +23,11 @@ export const usePutPreferenceNativeLanguage = (
           const nativeLanguages: GlobalLanguageCode[] =
             Array.from(nativeLanguagesSet)
 
-          await onUsePutPreference({ nativeLanguages })
+          await onPatchPreference({ nativeLanguages })
         } catch {}
       },
-    [onUsePutPreference, languageCode],
+    [onPatchPreference, languageCode],
   )
 
-  return onPutPreferenceNativeLanguage
+  return onPatchPreferenceNativeLanguage
 }

--- a/src/hooks/preference/use-patch-preference.hook.ts
+++ b/src/hooks/preference/use-patch-preference.hook.ts
@@ -1,19 +1,19 @@
 import { useRecoilCallback } from 'recoil'
 import { preferenceState } from '@/recoil/preferences/preference.state'
-import { putPreferenceApi } from '@/api/preferences/put-preference.api'
+import { patchPreferenceApi } from '@/api/preferences/patch-preference.api'
 import { PreferenceModifiable } from '@/api/preferences/index.interface'
 
-export const usePutPreference = () => {
-  const onPutPreference = useRecoilCallback(
+export const usePatchPreference = () => {
+  const onPatchPreference = useRecoilCallback(
     ({ set }) =>
       async (modifying: Partial<PreferenceModifiable>) => {
         try {
-          const [data] = await putPreferenceApi(modifying)
+          const [data] = await patchPreferenceApi(modifying)
           set(preferenceState, data)
         } catch {}
       },
     [],
   )
 
-  return onPutPreference
+  return onPatchPreference
 }


### PR DESCRIPTION
# Background
Use patch instead, as the `PUT` apis will be deprecated in the following issue: https://github.com/ajktown/api/issues/131

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
