### PR TITLE
Archive action group

### DIFF
--- a/src/api/action-groups/post-archive-action-group.api.ts
+++ b/src/api/action-groups/post-archive-action-group.api.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+interface PostArchiveActionGroupBodyDTO {
+  message: string
+}
+export const postArchiveActionGroupApi = async (
+  actionGroupId: string,
+  body: PostArchiveActionGroupBodyDTO,
+): Promise<void> => {
+  const url = `/v1/action-groups/${actionGroupId}/archive`
+  return axios.post(url, body)
+}

--- a/src/api/rituals/get-rituals.api.ts
+++ b/src/api/rituals/get-rituals.api.ts
@@ -16,13 +16,17 @@ export interface GetRitualsRes {
   rituals: IParentRitual[]
 }
 
+interface GetRitualQueryDTO {
+  isArchived: undefined | boolean
+}
+
 /**
  * The ritual group is not yet developed; cannot be modified yet
  */
-export const getRitualsApi = async (): Promise<
-  CustomizedAxiosResponse<GetRitualsRes>
-> => {
+export const getRitualsApi = async (
+  dto: GetRitualQueryDTO,
+): Promise<CustomizedAxiosResponse<GetRitualsRes>> => {
   const url = `/v1/rituals`
-  const res = await axios.get(url)
+  const res = await axios.get(url, { params: dto })
   return [res.data, res]
 }

--- a/src/components/dialog_archive_action_group/index.tsx
+++ b/src/components/dialog_archive_action_group/index.tsx
@@ -1,0 +1,69 @@
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
+import StyledTextField from '@/atoms/StyledTextField'
+import StyledTextWithHeaderIcon from '@/atoms/StyledTextWithHeaderIcon'
+import StyledDialog from '@/organisms/StyledDialog'
+import { DialogActions, DialogContent, DialogTitle, Stack } from '@mui/material'
+import { useCallback, FC, useState } from 'react'
+import WarningIcon from '@mui/icons-material/Warning'
+import { useRecoilValue, useResetRecoilState } from 'recoil'
+import { archivingActionGroupIdState } from '@/recoil/action-groups/action-groups.state'
+import { postArchiveActionGroupApi } from '@/api/action-groups/post-archive-action-group.api'
+import { useRituals } from '@/hooks/ritual/use-rituals.hook'
+
+const ArchiveActionGroupDialog: FC = () => {
+  const actionGroupId = useRecoilValue(archivingActionGroupIdState)
+  const onClose = useResetRecoilState(archivingActionGroupIdState)
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState(``)
+  const onGetRituals = useRituals()
+
+  const onPost = useCallback(async () => {
+    try {
+      setLoading(true)
+      await postArchiveActionGroupApi(actionGroupId, { message })
+      onGetRituals()
+
+      // Close dialog:
+      onClose()
+    } finally {
+      setLoading(false)
+    }
+  }, [message, actionGroupId, onClose, onGetRituals])
+
+  if (!actionGroupId) return null
+
+  return (
+    <StyledDialog onClose={onClose}>
+      <DialogTitle>{`Are you sure you want to archive this action group?`}</DialogTitle>
+      <DialogContent style={{ paddingTop: 20, paddingBottom: 20 }}>
+        <Stack spacing={1}>
+          <StyledTextField
+            isAutoFocused
+            value={message}
+            onChange={setMessage}
+            label={`Please write your motives for archiving this action group.`}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <StyledTextWithHeaderIcon
+          headerIcon={<WarningIcon color="warning" fontSize="small" />}
+          textProps={{
+            fontFamily: `Cormorant Garamond`,
+            variant: `caption`,
+            fontStyle: `italic`,
+          }}
+          title={`Be careful. You cannot unarchive action group after archiving.`}
+        />
+        <StyledTextButtonAtom
+          title="Yes, Archive this."
+          onClick={onPost}
+          isLoading={loading}
+          isDisabled={!message}
+        />
+      </DialogActions>
+    </StyledDialog>
+  )
+}
+
+export default ArchiveActionGroupDialog

--- a/src/components/dialog_archive_action_group/index.tsx
+++ b/src/components/dialog_archive_action_group/index.tsx
@@ -12,10 +12,17 @@ import { useRituals } from '@/hooks/ritual/use-rituals.hook'
 
 const ArchiveActionGroupDialog: FC = () => {
   const actionGroupId = useRecoilValue(archivingActionGroupIdState)
-  const onClose = useResetRecoilState(archivingActionGroupIdState)
+  const resetArchivingActionGroupId = useResetRecoilState(
+    archivingActionGroupIdState,
+  )
   const [loading, setLoading] = useState(false)
   const [message, setMessage] = useState(``)
   const onGetRituals = useRituals()
+
+  const onClose = useCallback(() => {
+    setMessage(``) // reset input message
+    resetArchivingActionGroupId()
+  }, [resetArchivingActionGroupId])
 
   const onPost = useCallback(async () => {
     try {

--- a/src/components/molecule_action_group_card/index.more-options.tsx
+++ b/src/components/molecule_action_group_card/index.more-options.tsx
@@ -1,8 +1,11 @@
-import { FC, useMemo } from 'react'
+import { FC, Fragment, useMemo } from 'react'
 import MoreIcon from '@mui/icons-material/MoreVert'
 import StyledIconButtonWithMenuAtom from '@/atoms/StyledIconButtonWithMenu'
-import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
-import { useRecoilValue } from 'recoil'
+import {
+  actionGroupFamily,
+  archivingActionGroupIdState,
+} from '@/recoil/action-groups/action-groups.state'
+import { useRecoilValue, useSetRecoilState } from 'recoil'
 import { ActionGroupFixedId } from '@/constants/action-group.constant'
 import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
 import { useDeleteTodayActionsByActionGroupId } from '@/hooks/action-group/use-delete-today-actions-by-action-group-id.hook'
@@ -47,35 +50,48 @@ const ActionGroupCardMoreOptions: FC<Props> = ({ id, nickname }) => {
     return !actionGroup.derivedState.isDeletable
   }, [actionGroup])
 
+  const setArchivingActionGroupId = useSetRecoilState(
+    archivingActionGroupIdState,
+  )
+
   // contains every loading state of a function:
   const everyLoading = loadingLatePost || loadingDelete || loadingDummyPost
 
   if (nickname) return null // if it is shared mode (or has nickname), do not show the button
 
   return (
-    <StyledIconButtonWithMenuAtom
-      menus={[
-        {
-          id: `today_not_committable`,
-          title: `Today Not Committable`,
-          isDisabled: isDummyCommittableDisabled || everyLoading,
-          onClick: onPostDummyActionByActionGroupId,
-        },
-        {
-          id: `commit_late`,
-          title: `Commit Late`,
-          isDisabled: isOnClickCommitLateDisabled || everyLoading,
-          onClick: onPostActionByActionGroupId,
-        },
-        {
-          id: `delete_today_actions`,
-          title: `Delete Today's Action`, // not actions (has "s") because API only allows one action per day atm in Mar 2024
-          isDisabled: isDeleteTodayActionsDisabled || everyLoading,
-          onClick: onDeleteTodayActionsByActionGroupId,
-        },
-      ]}
-      jsxElementButton={<MoreIcon />}
-    />
+    <Fragment>
+      <StyledIconButtonWithMenuAtom
+        menus={[
+          {
+            id: `today_not_committable`,
+            title: `Today Not Committable`,
+            isDisabled: isDummyCommittableDisabled || everyLoading,
+            onClick: onPostDummyActionByActionGroupId,
+          },
+          {
+            id: `commit_late`,
+            title: `Commit Late`,
+            isDisabled: isOnClickCommitLateDisabled || everyLoading,
+            onClick: onPostActionByActionGroupId,
+          },
+          {
+            id: `delete_today_actions`,
+            title: `Delete Today's Action`, // not actions (has "s") because API only allows one action per day atm in Mar 2024
+            isDisabled: isDeleteTodayActionsDisabled || everyLoading,
+            onClick: onDeleteTodayActionsByActionGroupId,
+          },
+          {
+            id: `archive_action_group`,
+            title: `Archive This Action Group`,
+            isDisabled:
+              everyLoading || id === ActionGroupFixedId.DailyPostWordChallenge,
+            onClick: () => setArchivingActionGroupId(id),
+          },
+        ]}
+        jsxElementButton={<MoreIcon />}
+      />
+    </Fragment>
   )
 }
 

--- a/src/components/organism_rituals_frame/index.tsx
+++ b/src/components/organism_rituals_frame/index.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil'
 import ActionGroupCard from '@/components/molecule_action_group_card'
 import { Stack } from '@mui/material'
 import { ActionGroupFixedId } from '@/constants/action-group.constant'
-
+import ArchiveActionGroupDialog from '../dialog_archive_action_group'
 interface Props {
   nickname?: string
 }
@@ -19,6 +19,7 @@ const RitualsFrame: FC<Props> = ({ nickname }) => {
       {actionGroupIds.map((id) => (
         <ActionGroupCard key={id} id={id} nickname={nickname} />
       ))}
+      <ArchiveActionGroupDialog />
     </Stack>
   )
 }

--- a/src/hooks/ritual/use-rituals.hook.ts
+++ b/src/hooks/ritual/use-rituals.hook.ts
@@ -14,7 +14,8 @@ export const useRituals = () => {
           let res: GetRitualsRes | null = null
 
           if (nickname) res = (await getUserRitualsApi({ nickname }))[0]
-          else res = (await getRitualById())[0]
+          // only archived action groups are requested by default atm:
+          else res = (await getRitualById({ isArchived: false }))[0]
 
           if (!res || res.rituals.length === 0) return
 

--- a/src/recoil/action-groups/action-groups.state.ts
+++ b/src/recoil/action-groups/action-groups.state.ts
@@ -6,6 +6,7 @@ import { GetActionGroupRes } from '@/api/action-groups/index.interface'
 enum Prk {
   ActionGroupIdsState = `ActionGroupIdsState`,
   ActionGroupsState = `ActionGroupState`,
+  ArchivingActionGroupIdState = `ArchivingActionGroupIdState`,
 }
 
 type ActionGroupState = undefined | null | GetActionGroupRes
@@ -17,4 +18,11 @@ export const actionGroupFamily = atomFamily<ActionGroupState, string>({
 export const actionGroupIdsState = atom<string[]>({
   key: Rkp.ActionGroups + Prk.ActionGroupIdsState,
   default: [],
+})
+
+// if empty string, dialog does not show up
+// if not empty string, dialog shows up, trying to archive the action group
+export const archivingActionGroupIdState = atom<string>({
+  key: Rkp.ActionGroups + Prk.ArchivingActionGroupIdState,
+  default: ``,
 })


### PR DESCRIPTION
# Background
You can now archive action group once you no longer follow it:
<img width="1159" alt="image" src="https://github.com/ajktown/ConsistencyGPT/assets/53258958/45b82254-3b6d-47a8-8ddb-8ae304c48df0">

This depends on the API built: https://github.com/ajktown/api/pull/134

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `TODOs` are filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `yarn inspect` is run
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled
