### PR TITLE
Setting page's action group relocation does not make archived action groups appeared

### DIFF
--- a/src/api/rituals/patch-ritual.api.ts
+++ b/src/api/rituals/patch-ritual.api.ts
@@ -4,6 +4,7 @@ import { IParentRitual } from './get-rituals.api'
 
 export interface PatchRitualGroupBodyDTO {
   actionGroupIds: string[]
+  isArchived: boolean
 }
 
 export interface GetRitualByIdRes {

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -10,7 +10,10 @@ export const usePatchRitual = () => {
     ({ set }) =>
       async (dto: Partial<PatchRitualGroupBodyDTO>) => {
         try {
-          const [data] = await patchRitualApi(dto)
+          const [data] = await patchRitualApi({
+            ...dto,
+            isArchived: true, // fixed
+          })
           set(actionGroupIdsState, data.ritual.actionGroupIds)
         } catch {}
       },


### PR DESCRIPTION
# Background
When you move your action group up or down, archived action groups also appeared. This is due to that API did not support `isArchived` beforehand.

The API is now supported with the following PR: https://github.com/ajktown/api/pull/141

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - `TODOs` are handled and checked
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


