### PR TITLE
Fix: duplicated templates found; removed

### DIFF
--- a/src/pages/users/[nickname].tsx
+++ b/src/pages/users/[nickname].tsx
@@ -64,7 +64,6 @@ const UserByNicknamePage: FC = () => {
           <RitualsFrame nickname={nickname} />
         </Grid2>
       </Grid2>
-      <RitualsFrame nickname={nickname} />
     </Appbar>
   )
 }


### PR DESCRIPTION
# Background
Two frames exist at the same page without any state.

The blue box is removed:
- Red: the first frame (the correct one)
- Blue: the second frame (duplicated one)
![image](https://github.com/user-attachments/assets/6d576a41-ffac-4678-be0d-83e39fa519ca)


## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


