### PR TITLE
fix: dialog only when `actionGroupAchievedPercentSelector`

### DIFF
--- a/src/components/organism_rituals_frame/index.gague-dialog.tsx
+++ b/src/components/organism_rituals_frame/index.gague-dialog.tsx
@@ -16,11 +16,13 @@ const RitualsFrameGaugeDialog: FC = () => {
   const percentage = useRecoilValue(actionGroupAchievedPercentSelector)
 
   useEffect(() => {
+    if (visual === percentage) return // if it is the same, we should not show anything!
+
     // if percentage changes, open it for two seconds, and close it
     setTimeout(() => setOpen(true), 400)
     setTimeout(() => setVisual(percentage), 850)
     setTimeout(() => setOpen(false), 2500)
-  }, [percentage])
+  }, [visual, percentage])
 
   if (!open) return null
 

--- a/src/recoil/action-groups/action-groups.selectors.ts
+++ b/src/recoil/action-groups/action-groups.selectors.ts
@@ -20,7 +20,7 @@ export const actionGroupAchievedPercentSelector = selector<number>({
     const ids = get(actionGroupIdsState)
     for (const id of ids) {
       const actionGroup = get(actionGroupFamily(id))
-      if (!actionGroup) continue // empty action groups are not counted
+      if (!actionGroup) return 0 // this means it is not yet ready
 
       totalCounts++
       if (actionGroup.isTodayHandled) achievedCount++


### PR DESCRIPTION
# Background
Dialog opens/closes within few seconds, as the action group data is changed once open

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


