### PR TITLE
Feat: Shows year chip with first year

### DIFF
--- a/src/api/action-groups/index.interface.ts
+++ b/src/api/action-groups/index.interface.ts
@@ -26,6 +26,7 @@ export interface IActionGroupInput extends DataBasics {
 }
 
 export interface IActionGroup extends IActionGroupInput {
+  firstYear: number
   openAt: Date
   closeAt: Date
   utc: string // i.e) +9:00 (timezone is private to shared data)

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -1,5 +1,5 @@
 import { FC, Fragment, useCallback } from 'react'
-import { Box, Card, Stack, Typography } from '@mui/material'
+import { Box, Card, Stack } from '@mui/material'
 import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
 import { useActionGroupById } from '@/hooks/action-group/use-action-group-by-id.hook'
 import ActivityCalendarById from '../molecule_activity_calendar/index.by-id'
@@ -40,7 +40,9 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
           )}
         </Stack>
       </Stack>
-      <ActionGroupCardYears id={id} />
+      <Box mt={2} mr={2} mb={2}>
+        <ActionGroupCardYears id={id} />
+      </Box>
     </Card>
   )
 }

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -1,5 +1,5 @@
 import { FC, Fragment, useCallback } from 'react'
-import { Card, Stack } from '@mui/material'
+import { Box, Card, Stack, Typography } from '@mui/material'
 import StyledCloudRefresher from '@/atoms/StyledCloudRefresher'
 import { useActionGroupById } from '@/hooks/action-group/use-action-group-by-id.hook'
 import ActivityCalendarById from '../molecule_activity_calendar/index.by-id'
@@ -7,6 +7,7 @@ import ActionGroupCardButton from './index.buttons'
 import ActionGroupCardTitle from './index.title'
 import ActionGroupCardSpecialMessage from './index.special-message'
 import ActionGroupCardMoreOptions from './index.more-options'
+import ActionGroupCardYears from './index.years'
 
 interface Props {
   id: string
@@ -21,7 +22,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
   }, [nickname, onGetActionGroupById])
 
   return (
-    <Card>
+    <Card sx={{ display: `flex`, flexDirection: `row` }}>
       <Stack m={3}>
         {/* Header */}
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
@@ -39,6 +40,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
           )}
         </Stack>
       </Stack>
+      <ActionGroupCardYears id={id} />
     </Card>
   )
 }

--- a/src/components/molecule_action_group_card/index.years.tsx
+++ b/src/components/molecule_action_group_card/index.years.tsx
@@ -1,3 +1,4 @@
+import StyledTextButtonAtom from '@/atoms/StyledTextButton'
 import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
 import { Stack } from '@mui/material'
 import { FC } from 'react'
@@ -12,15 +13,25 @@ const ActionGroupCardYears: FC<Props> = ({ id }) => {
   const actionGroup = useRecoilValue(actionGroupFamily(id))
   if (!actionGroup) return null
 
-  // like this: [2024, 2023, 2022 ...]
   const yearsArray = Array.from(
+    // like this: [2024, 2023, 2022 ...]
     { length: endYear - actionGroup.props.firstYear + 1 },
     (_, i) => endYear - i,
   )
-  // TODO: Requires a visual that shows a button! 
-  // TODO: Test if returned first year 2013 works too!
+
   // TODO: Make sure that the buttons are not yet clickable as the API does not handle it yet!
-  return <Stack alignItems="center">{yearsArray.join(`,`)}</Stack>
+  return (
+    <Stack alignItems="center" spacing={0.5}>
+      {yearsArray.map((year) => (
+        <StyledTextButtonAtom
+          key={year}
+          isDisabled={year !== endYear}
+          title={year.toString()}
+          color={year === endYear ? `primary` : undefined}
+        />
+      ))}
+    </Stack>
+  )
 }
 
 export default ActionGroupCardYears

--- a/src/components/molecule_action_group_card/index.years.tsx
+++ b/src/components/molecule_action_group_card/index.years.tsx
@@ -1,0 +1,26 @@
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { Stack } from '@mui/material'
+import { FC } from 'react'
+import { useRecoilValue } from 'recoil'
+interface Props {
+  id: string
+}
+
+const endYear = new Date().getFullYear() // Today's year like 2024
+
+const ActionGroupCardYears: FC<Props> = ({ id }) => {
+  const actionGroup = useRecoilValue(actionGroupFamily(id))
+  if (!actionGroup) return null
+
+  // like this: [2024, 2023, 2022 ...]
+  const yearsArray = Array.from(
+    { length: endYear - actionGroup.props.firstYear + 1 },
+    (_, i) => endYear - i,
+  )
+  // TODO: Requires a visual that shows a button! 
+  // TODO: Test if returned first year 2013 works too!
+  // TODO: Make sure that the buttons are not yet clickable as the API does not handle it yet!
+  return <Stack alignItems="center">{yearsArray.join(`,`)}</Stack>
+}
+
+export default ActionGroupCardYears


### PR DESCRIPTION
# Background
Issue: https://github.com/ajktown/ConsistencyGPT/issues/8

With the `firstYear` from the API server: https://github.com/ajktown/api/pull/146,
We simply show the years like this:
![image](https://github.com/user-attachments/assets/3ed4a192-923c-4ff9-b4f5-7bfbfb3ac07c)

If many years:
![image](https://github.com/user-attachments/assets/df73d28e-1dc1-4cf6-b9e2-c762df228447)



## What is not done
- The API does not yet support the filter for the year, so you cannot click it for now.


## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


