### PR TITLE
bugfix: changing order of action groups not working properly on UI

### DIFF
--- a/src/api/rituals/patch-ritual.api.ts
+++ b/src/api/rituals/patch-ritual.api.ts
@@ -1,19 +1,17 @@
 import axios from 'axios'
 import { CustomizedAxiosResponse } from '../index.interface'
-import { IParentRitual } from './get-rituals.api'
+import { GetRitualsRes } from './get-rituals.api'
 
 export interface PatchRitualGroupBodyDTO {
   actionGroupIds: string[]
   isArchived: boolean
 }
 
-export interface GetRitualByIdRes {
-  ritual: IParentRitual
-}
+type PatchRitualRes = GetRitualsRes
 
 export const patchRitualApi = async (
   dto: Partial<PatchRitualGroupBodyDTO>,
-): Promise<CustomizedAxiosResponse<GetRitualByIdRes>> => {
+): Promise<CustomizedAxiosResponse<PatchRitualRes>> => {
   const url = `/v1/rituals/default`
   const res = await axios.patch(url, dto)
   return [res.data, res]

--- a/src/hooks/ritual/use-patch-ritual.hook.ts
+++ b/src/hooks/ritual/use-patch-ritual.hook.ts
@@ -12,9 +12,9 @@ export const usePatchRitual = () => {
         try {
           const [data] = await patchRitualApi({
             ...dto,
-            isArchived: true, // fixed
+            isArchived: false, // fixed
           })
-          set(actionGroupIdsState, data.ritual.actionGroupIds)
+          set(actionGroupIdsState, data.rituals[0].actionGroupIds)
         } catch {}
       },
     [],


### PR DESCRIPTION
# Background
We need to modify the FE to handle the returned data accordingly as API now returns `GetRitualsResDTO` instead:
![image](https://github.com/user-attachments/assets/ce0aab96-2ff8-4ca9-8134-359fac7dcaf9)
https://github.com/ajktown/api/pull/149

Additionally, there is a bug where the patch rituals sends `isArchived: true`,  `isArchived: true`, which should be `isArchived: true`, as you do not want to get archived action groups in setting.

## What's done
- `isArchived: true` => `isArchived: false`
- Correct the type for the expected return response

## Checklist Before PR Review
- [x] The following has been handled:
  -  `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR

## Checklist (Reviewers)
- [x] Check if there are any other missing TODOs that are not yet listed
- [x] Review Code
- [x] Every item on the checklist has been addressed accordingly
- [x] If `development` is associated to this PR, you must check if every TODOs are handled


