### PR TITLE
Bugfix/clean view on mobile as well with year selection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "ajktown",
     "Appbar",
     "mlajkim",
+    "Punchable",
     "WORDNOTE"
   ]
 }

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -1,7 +1,6 @@
 import StyledCircularButtonAtom from '@/atoms/StyledCircularButton'
-import { ActionGroupFixedId } from '@/constants/action-group.constant'
 import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
-import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { isActionGroupPunchableSelector } from '@/recoil/action-groups/action-groups.selectors'
 import { FC } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -9,14 +8,13 @@ interface Props {
   id: string
 }
 const ActionGroupCardButton: FC<Props> = ({ id }) => {
-  const actionGroup = useRecoilValue(actionGroupFamily(id))
+  const isActionGroupPunchable = useRecoilValue(
+    isActionGroupPunchableSelector(id),
+  )
   const [loading, onPostActionByActionGroupId] =
     usePostActionByActionGroupId(id)
 
-  if (!actionGroup) return null
-  if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
-    return null
-  if (!actionGroup.derivedState.isOnTimeCommittable) return null
+  if (!isActionGroupPunchable) return null
 
   return (
     <StyledCircularButtonAtom

--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -20,7 +20,7 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
     <StyledCircularButtonAtom
       onClick={onPostActionByActionGroupId}
       radius={80}
-      bgColor="green"
+      bgColor="green" // TODO: Just learned that the #XXXXXX works here xDD
       title="Done!"
       loading={loading}
       typoProps={{

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -8,8 +8,6 @@ import ActionGroupCardTitle from './index.title'
 import ActionGroupCardSpecialMessage from './index.special-message'
 import ActionGroupCardMoreOptions from './index.more-options'
 import ActionGroupCardYears from './index.years'
-import { isActionGroupPunchableSelector } from '@/recoil/action-groups/action-groups.selectors'
-import { useRecoilValue } from 'recoil'
 
 interface Props {
   id: string
@@ -17,9 +15,6 @@ interface Props {
 }
 const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
   const onGetActionGroupById = useActionGroupById(id)
-  const isActionGroupPunchable = useRecoilValue(
-    isActionGroupPunchableSelector(id),
-  )
 
   const onClickRefresh = useCallback(async () => {
     // run all together
@@ -46,11 +41,9 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
           )}
         </Stack>
       </Stack>
-      {!isActionGroupPunchable && (
-        <Box pt={2} pr={2} pb={2}>
-          <ActionGroupCardYears id={id} />
-        </Box>
-      )}
+      <Box pt={2} pr={2} pb={2}>
+        <ActionGroupCardYears id={id} />
+      </Box>
     </Card>
   )
 }

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -32,6 +32,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
         {/* Header */}
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
           <ActionGroupCardTitle id={id} />
+          <Box flex={1} />
           <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
           <ActionGroupCardMoreOptions id={id} nickname={nickname} />
         </Stack>

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -8,6 +8,8 @@ import ActionGroupCardTitle from './index.title'
 import ActionGroupCardSpecialMessage from './index.special-message'
 import ActionGroupCardMoreOptions from './index.more-options'
 import ActionGroupCardYears from './index.years'
+import { isActionGroupPunchableSelector } from '@/recoil/action-groups/action-groups.selectors'
+import { useRecoilValue } from 'recoil'
 
 interface Props {
   id: string
@@ -15,6 +17,9 @@ interface Props {
 }
 const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
   const onGetActionGroupById = useActionGroupById(id)
+  const isActionGroupPunchable = useRecoilValue(
+    isActionGroupPunchableSelector(id),
+  )
 
   const onClickRefresh = useCallback(async () => {
     // run all together
@@ -23,7 +28,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
 
   return (
     <Card sx={{ display: `flex`, flexDirection: `row` }}>
-      <Stack m={3}>
+      <Stack m={3} width="100%">
         {/* Header */}
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
           <ActionGroupCardTitle id={id} />
@@ -40,9 +45,11 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
           )}
         </Stack>
       </Stack>
-      <Box mt={2} mr={2} mb={2}>
-        <ActionGroupCardYears id={id} />
-      </Box>
+      {!isActionGroupPunchable && (
+        <Box pt={2} pr={2} pb={2}>
+          <ActionGroupCardYears id={id} />
+        </Box>
+      )}
     </Card>
   )
 }

--- a/src/components/molecule_action_group_card/index.years.tsx
+++ b/src/components/molecule_action_group_card/index.years.tsx
@@ -1,4 +1,5 @@
 import ThemedTextButtonAtom from '@/atoms_themed/ThemedTextButton'
+import { isActionGroupPunchableSelector } from '@/recoil/action-groups/action-groups.selectors'
 import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
 import { Stack } from '@mui/material'
 import { FC } from 'react'
@@ -10,8 +11,12 @@ interface Props {
 const endYear = new Date().getFullYear() // Today's year like 2024
 
 const ActionGroupCardYears: FC<Props> = ({ id }) => {
+  const isActionGroupPunchable = useRecoilValue(
+    isActionGroupPunchableSelector(id),
+  )
   const actionGroup = useRecoilValue(actionGroupFamily(id))
-  if (!actionGroup) return null
+  if (!actionGroup) return null // cannot show the year chips as the action group is not loaded yet
+  if (isActionGroupPunchable) return null // does not show the year chip so that users can focus on achieving (punching) the goal
 
   const yearsArray = Array.from(
     // like this: [2024, 2023, 2022 ...]

--- a/src/components/molecule_activity_calendar/index.by-id.tsx
+++ b/src/components/molecule_activity_calendar/index.by-id.tsx
@@ -13,7 +13,7 @@ interface Props {
   id: string
 }
 
-const SHRINKING_MIN_WIDTH = 920 // starting width that makes the calendar shrink
+const SHRINKING_MIN_WIDTH = 1020 // starting width that makes the calendar shrink
 const COMMIT_BLOCK_WIDTH = 16 // 12 x 12 with 2 indent between
 
 const ActivityCalendarById: FC<Props> = ({ id }) => {

--- a/src/components/organism_rituals_frame/index.tsx
+++ b/src/components/organism_rituals_frame/index.tsx
@@ -8,17 +8,20 @@ import ArchiveActionGroupDialog from '../dialog_archive_action_group'
 interface Props {
   nickname?: string
 }
+const FRAME_MAX_WIDTH = 980
 const RitualsFrame: FC<Props> = ({ nickname }) => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
 
   return (
-    <Stack alignItems={`center`} spacing={2} p={2}>
-      {!nickname && (
-        <ActionGroupCard id={ActionGroupFixedId.DailyPostWordChallenge} />
-      )}
-      {actionGroupIds.map((id) => (
-        <ActionGroupCard key={id} id={id} nickname={nickname} />
-      ))}
+    <Stack alignItems={`center`}>
+      <Stack maxWidth={FRAME_MAX_WIDTH} spacing={2} p={2}>
+        {!nickname && (
+          <ActionGroupCard id={ActionGroupFixedId.DailyPostWordChallenge} />
+        )}
+        {actionGroupIds.map((id) => (
+          <ActionGroupCard key={id} id={id} nickname={nickname} />
+        ))}
+      </Stack>
       <ArchiveActionGroupDialog />
     </Stack>
   )

--- a/src/recoil/action-groups/action-groups.selectors.ts
+++ b/src/recoil/action-groups/action-groups.selectors.ts
@@ -1,10 +1,12 @@
-import { selector } from 'recoil'
+import { selector, selectorFamily } from 'recoil'
 import { Rkp, Rks } from '../index.keys'
 import { actionGroupFamily, actionGroupIdsState } from './action-groups.state'
+import { ActionGroupFixedId } from '@/constants/action-group.constant'
 
 /** Private Recoil Key */
 enum Prk {
   ActionGroupAchievedPercentSelector = `actionGroupAchievedPercentSelector`,
+  IsActionGroupPunchableSelector = `isActionGroupPunchableSelector`,
 }
 
 /**
@@ -29,4 +31,20 @@ export const actionGroupAchievedPercentSelector = selector<number>({
     if (totalCounts === 0) return 0
     return Math.floor((achievedCount / totalCounts) * 100)
   },
+})
+
+/**
+ * isActionGroupPunchableSelector defines if the action group is punchable (the green button with "DONE!" text)
+ */
+export const isActionGroupPunchableSelector = selectorFamily<boolean, string>({
+  key: Rkp.ActionGroups + Prk.IsActionGroupPunchableSelector + Rks.Selector,
+  get:
+    (id: string) =>
+    ({ get }) => {
+      const actionGroup = get(actionGroupFamily(id))
+      if (!actionGroup) return false // not punchable
+      if (actionGroup.props.id === ActionGroupFixedId.DailyPostWordChallenge)
+        return false // not punchable
+      return actionGroup.derivedState.isOnTimeCommittable
+    },
 })


### PR DESCRIPTION
# Background
The current UI is not smart enough to handle the visual changes with different width size.

Also each action group does not have fixed width size as issued below:
![image](https://github.com/user-attachments/assets/94d87f86-1669-4675-a84e-596cc1dd5243)
https://github.com/ajktown/ConsistencyGPT/issues/65

## What's done
### Width overflow removed:
![image](https://github.com/user-attachments/assets/be83bdc2-6907-4ab1-80de-f1777ee0ffc7)

### The year chip (pink box) is removed when punchable state:
![image](https://github.com/user-attachments/assets/13c63683-e39d-4345-818e-31d559063a2d)

### Action group card gets fixed width despite its title, and have the same width despite its title:
#### *(too short)*
![image](https://github.com/user-attachments/assets/9335382d-aefa-4233-beb7-3f2aa8d4526b)

#### *(too long)*
![image](https://github.com/user-attachments/assets/8b006119-080a-4335-95e8-8dbf4de98cc3)

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


