### PR TITLE
Feat: shows streak

### DIFF
--- a/src/api/action-groups/index.interface.ts
+++ b/src/api/action-groups/index.interface.ts
@@ -53,6 +53,7 @@ interface ActionGroupDerivedState {
 
 export interface GetActionGroupRes {
   props: IActionGroup
+  streak: number
   actionsLength: number
   isTodayHandled: boolean
   totalCount: number

--- a/src/components/molecule_action_group_card/index.streak.tsx
+++ b/src/components/molecule_action_group_card/index.streak.tsx
@@ -1,0 +1,28 @@
+import StyledTextWithHeaderIcon from '@/atoms/StyledTextWithHeaderIcon'
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { FC } from 'react'
+import { useRecoilValue } from 'recoil'
+import StreakIcon from '@mui/icons-material/ElectricBolt'
+interface Props {
+  id: string
+}
+
+const ActionGroupCardStreak: FC<Props> = ({ id }) => {
+  const actionGroup = useRecoilValue(actionGroupFamily(id))
+
+  if (!actionGroup) return null
+  if (actionGroup.streak === 0) return null // if 0, it should probably not remind the user
+
+  return (
+    <StyledTextWithHeaderIcon
+      headerIcon={<StreakIcon color="warning" fontSize="small" />}
+      textProps={{
+        fontFamily: `Cormorant Garamond`,
+        variant: `caption`,
+      }}
+      title={`${actionGroup.streak}`}
+    />
+  )
+}
+
+export default ActionGroupCardStreak

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -8,6 +8,7 @@ import ActionGroupCardTitle from './index.title'
 import ActionGroupCardSpecialMessage from './index.special-message'
 import ActionGroupCardMoreOptions from './index.more-options'
 import ActionGroupCardYears from './index.years'
+import ActionGroupCardStreak from './index.streak'
 
 interface Props {
   id: string
@@ -28,6 +29,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
           <ActionGroupCardTitle id={id} />
           <Box flex={1} />
+          <ActionGroupCardStreak id={id} />
           <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />
           <ActionGroupCardMoreOptions id={id} nickname={nickname} />
         </Stack>


### PR DESCRIPTION
# Background
ajktown-api now returns `streak` for each action group: https://github.com/ajktown/api/pull/151
We want to now show the streak for each action group to motivate users not to lose their streak!

## What's done
Shows the streak in the blue box:
![image](https://github.com/user-attachments/assets/83126188-e2fe-4b7d-b7ac-d2b645453e9b)

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


