### PR TITLE
Feat: `Done!` with theme color

### DIFF
--- a/src/components/molecule_action_group_card/index.buttons.tsx
+++ b/src/components/molecule_action_group_card/index.buttons.tsx
@@ -1,6 +1,8 @@
 import StyledCircularButtonAtom from '@/atoms/StyledCircularButton'
 import { usePostActionByActionGroupId } from '@/hooks/action-group/use-post-action-by-action-group-id.hook'
 import { isActionGroupPunchableSelector } from '@/recoil/action-groups/action-groups.selectors'
+import { getDoneColorLambda } from '@/lambdas/get-app-theme-color.lambda'
+import { appThemeState } from '@/recoil/app-theme/app-theme.state'
 import { FC } from 'react'
 import { useRecoilValue } from 'recoil'
 
@@ -11,6 +13,7 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
   const isActionGroupPunchable = useRecoilValue(
     isActionGroupPunchableSelector(id),
   )
+  const appTheme = useRecoilValue(appThemeState)
   const [loading, onPostActionByActionGroupId] =
     usePostActionByActionGroupId(id)
 
@@ -20,7 +23,7 @@ const ActionGroupCardButton: FC<Props> = ({ id }) => {
     <StyledCircularButtonAtom
       onClick={onPostActionByActionGroupId}
       radius={80}
-      bgColor="green" // TODO: Just learned that the #XXXXXX works here xDD
+      bgColor={getDoneColorLambda(appTheme)}
       title="Done!"
       loading={loading}
       typoProps={{

--- a/src/lambdas/get-app-theme-color.lambda.ts
+++ b/src/lambdas/get-app-theme-color.lambda.ts
@@ -114,3 +114,17 @@ export const getButtonColorLambda = (
     }
   }
 }
+
+/**
+ * Color for the done button
+ */
+export const getDoneColorLambda = (theme?: AppTheme): string => {
+  switch (theme) {
+    case AppTheme.Halloween:
+      return Halloween.five
+    case AppTheme.Christmas:
+      return Christmas.five
+    default:
+      return `green`
+  }
+}


### PR DESCRIPTION
# Background
![image](https://github.com/user-attachments/assets/1ac315f2-b957-4039-9a82-436c7d3a08fe)
`appTheme` is not applied for the button `Done!`

## What's done
`appTheme` is applied

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


