### PR TITLE
Feat: new button for setting

### DIFF
--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback, useState } from 'react'
 import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
-import { useRecoilValue } from 'recoil'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
 import { List, ListItem, ListItemText, Stack } from '@mui/material'
 import SettingFrameRefresher from './index.setting-refresher'
 import StyledIconButtonAtom from '@/atoms/StyledIconButton'
@@ -22,26 +22,31 @@ const SettingFrame: FC = () => {
     router.push(PageConst.Home)
   }, [router])
 
-  const onClickArrow = useCallback(
-    async (id: string, isUpward = true) => {
-      try {
+  const onClickSave = useCallback(async () => {
+    try {
+      await onPatchRitual({ actionGroupIds: actionGroupIds })
+    } catch {}
+  }, [actionGroupIds, onPatchRitual])
+
+  const onClickArrow = useRecoilCallback(
+    ({ set }) =>
+      async (id: string, isUpward = true) => {
         const index = actionGroupIds.findIndex(
           (actionGroupId) => actionGroupId === id,
         )
         const newActionGroupIds = [...actionGroupIds]
         const tmp = newActionGroupIds[index]
-
         const newIndex = isUpward ? -1 : 1
         newActionGroupIds[index] = newActionGroupIds[index + newIndex]
         newActionGroupIds[index + newIndex] = tmp
-        await onPatchRitual({ actionGroupIds: newActionGroupIds })
+
+        set(actionGroupIdsState, newActionGroupIds)
 
         // highlight modified action group so that it is  easier to track:
         setHighlightedId(id)
         setTimeout(() => setHighlightedId(null), 0.4 * 1000) // seconds
-      } catch {}
-    },
-    [actionGroupIds, onPatchRitual],
+      },
+    [actionGroupIds],
   )
 
   return (
@@ -50,6 +55,7 @@ const SettingFrame: FC = () => {
         title={`Back to main page`}
         onClick={onClickToHomePage}
       />
+      <ThemedTextButtonAtom title={`Save`} onClick={onClickSave} />
       <List sx={{ width: `100%`, maxWidth: 700, bgcolor: `background.paper` }}>
         {actionGroupIds.map((id, i) => (
           <ListItem


### PR DESCRIPTION
# Background
Saving the changes of order everytime the button is clicked takes too much time.

## What's done
Implement a very simple button for save instead:
![image](https://github.com/user-attachments/assets/b3a51a7c-c0a5-4b2e-955c-dfc725ed600f)

## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


