### PR TITLE
Feat: Title Copier for ActionGroupCard

### DIFF
--- a/src/components/molecule_action_group_card/index.title-copier.tsx
+++ b/src/components/molecule_action_group_card/index.title-copier.tsx
@@ -1,0 +1,29 @@
+import { actionGroupFamily } from '@/recoil/action-groups/action-groups.state'
+import { FC, useCallback } from 'react'
+import { useRecoilValue } from 'recoil'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import StyledIconButtonAtom from '@/atoms/StyledIconButton'
+interface Props {
+  id: string
+}
+
+const ActionGroupCardTitleCopier: FC<Props> = ({ id }) => {
+  const actionGroup = useRecoilValue(actionGroupFamily(id))
+
+  const onClick = useCallback(() => {
+    if (!actionGroup) return // disabled as action-group info is not loaded yet
+    navigator.clipboard.writeText(actionGroup.props.task)
+  }, [actionGroup])
+
+  if (!actionGroup) return null
+
+  return (
+    <StyledIconButtonAtom
+      onClick={onClick}
+      isDisabled={!actionGroup}
+      jsxElementButton={<ContentCopyIcon fontSize="small" />}
+    />
+  )
+}
+
+export default ActionGroupCardTitleCopier

--- a/src/components/molecule_action_group_card/index.title-copier.tsx
+++ b/src/components/molecule_action_group_card/index.title-copier.tsx
@@ -11,6 +11,8 @@ interface Props {
  * ActionGroupCardTitleCopier renders a copy button for action-group's task if it exists
  */
 const ActionGroupCardTitleCopier: FC<Props> = ({ id }) => {
+  // task "": we have nothing to copy, so the button will be disabled (hidden)
+  // task non-empty-string: we have something to copy, so the button will be enabled (shown)
   const task: string = useRecoilValue(actionGroupFamily(id))?.props.task ?? ``
 
   const onClick = useCallback(() => {

--- a/src/components/molecule_action_group_card/index.title-copier.tsx
+++ b/src/components/molecule_action_group_card/index.title-copier.tsx
@@ -7,20 +7,22 @@ interface Props {
   id: string
 }
 
+/**
+ * ActionGroupCardTitleCopier renders a copy button for action-group's task if it exists
+ */
 const ActionGroupCardTitleCopier: FC<Props> = ({ id }) => {
-  const actionGroup = useRecoilValue(actionGroupFamily(id))
+  const task: string = useRecoilValue(actionGroupFamily(id))?.props.task ?? ``
 
   const onClick = useCallback(() => {
-    if (!actionGroup) return // disabled as action-group info is not loaded yet
-    navigator.clipboard.writeText(actionGroup.props.task)
-  }, [actionGroup])
+    if (!task) return // disabled as action-group info is not loaded yet
+    navigator.clipboard.writeText(task)
+  }, [task])
 
-  if (!actionGroup) return null
+  if (!task) return null
 
   return (
     <StyledIconButtonAtom
       onClick={onClick}
-      isDisabled={!actionGroup}
       jsxElementButton={<ContentCopyIcon fontSize="small" />}
     />
   )

--- a/src/components/molecule_action_group_card/index.tsx
+++ b/src/components/molecule_action_group_card/index.tsx
@@ -9,6 +9,7 @@ import ActionGroupCardSpecialMessage from './index.special-message'
 import ActionGroupCardMoreOptions from './index.more-options'
 import ActionGroupCardYears from './index.years'
 import ActionGroupCardStreak from './index.streak'
+import ActionGroupCardTitleCopier from './index.title-copier'
 
 interface Props {
   id: string
@@ -28,6 +29,7 @@ const ActionGroupCard: FC<Props> = ({ id, nickname }) => {
         {/* Header */}
         <Stack alignItems="center" direction={`row`} spacing={0.5} m={2}>
           <ActionGroupCardTitle id={id} />
+          <ActionGroupCardTitleCopier id={id} />
           <Box flex={1} />
           <ActionGroupCardStreak id={id} />
           <StyledCloudRefresher onClick={onClickRefresh} runOnClickOnce />


### PR DESCRIPTION
# Background
Sometimes I want to copy the title of ActionGroup

## What's done
Implement a button for copying the title of the ActionGroup:
![image](https://github.com/user-attachments/assets/b425df1d-4960-421c-9ae3-89e419ca1b7f)


## What are the related PRs?
- N/A

## Checklist Before PR Review
- [x] The following has been handled:
  - `Draft` is set for this PR
  - `Title` is checked
  - `Background` is filled
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done
  - Make this PR as an open PR
  - `What's done` is filled & matches to the actual changes

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists


