### PR TITLE
Feat: `useProgresssDialog` in `Preference` modifiable on the UI

### DIFF
--- a/src/api/preferences/index.interface.ts
+++ b/src/api/preferences/index.interface.ts
@@ -11,7 +11,7 @@ interface IPreferenceCGT {
   useProgressDialog: boolean
 }
 
-export interface PreferenceModifiable {
+export interface PreferenceModifiable extends IPreferenceCGT {
   nativeLanguages: GlobalLanguageCode[]
   selectedDictIds: string[]
 }

--- a/src/components/atom_use_progress_dialog_switch/index.tsx
+++ b/src/components/atom_use_progress_dialog_switch/index.tsx
@@ -32,8 +32,8 @@ const UseProgressDialogSwitch: FC = () => {
         }}
         switchProps={{
           onChange,
-          checked: useProgressDialog || loading,
-          disabled: useProgressDialog === undefined, // if undefined (So not boolean) we do not have data yet so we disable the switch
+          checked: Boolean(useProgressDialog),
+          disabled: useProgressDialog === undefined || loading, // Disable the switch if data is not available or an operation is in progress
         }}
       />
     </Stack>

--- a/src/components/atom_use_progress_dialog_switch/index.tsx
+++ b/src/components/atom_use_progress_dialog_switch/index.tsx
@@ -1,0 +1,43 @@
+import StyledSwitch from '@/atoms/StyledSwitch'
+import { usePatchPreference } from '@/hooks/preference/use-patch-preference.hook'
+import { preferenceState } from '@/recoil/preferences/preference.state'
+import { Stack, Typography } from '@mui/material'
+import { FC, useCallback, useState } from 'react'
+import { useRecoilValue } from 'recoil'
+
+const UseProgressDialogSwitch: FC = () => {
+  const useProgressDialog: boolean | undefined =
+    useRecoilValue(preferenceState)?.useProgressDialog
+  const onPatchPreference = usePatchPreference()
+
+  const [loading, setLoading] = useState(false)
+
+  const onChange = useCallback(async () => {
+    try {
+      setLoading(true)
+      await onPatchPreference({ useProgressDialog: !useProgressDialog })
+    } finally {
+      setLoading(false)
+    }
+  }, [useProgressDialog, onPatchPreference, setLoading])
+
+  return (
+    <Stack alignItems={`center`} spacing={2} p={2} direction="row">
+      <Typography>{`Use Progress Dialog?`}</Typography>
+      <StyledSwitch
+        tooltipProps={{
+          title: useProgressDialog
+            ? `Hide archived words`
+            : `Show archived words`,
+        }}
+        switchProps={{
+          onChange,
+          checked: useProgressDialog || loading,
+          disabled: useProgressDialog === undefined, // if undefined (So not boolean) we do not have data yet so we disable the switch
+        }}
+      />
+    </Stack>
+  )
+}
+
+export default UseProgressDialogSwitch

--- a/src/components/atom_use_progress_dialog_switch/index.tsx
+++ b/src/components/atom_use_progress_dialog_switch/index.tsx
@@ -27,8 +27,8 @@ const UseProgressDialogSwitch: FC = () => {
       <StyledSwitch
         tooltipProps={{
           title: useProgressDialog
-            ? `Hide archived words`
-            : `Show archived words`,
+            ? `Disable progress dialog`
+            : `Enable progress dialog`,
         }}
         switchProps={{
           onChange,

--- a/src/components/organism_appbar/index.tsx
+++ b/src/components/organism_appbar/index.tsx
@@ -15,6 +15,7 @@ import { getAppBarColorLambda } from '@/lambdas/get-app-theme-color.lambda'
 import { useRecoilValue } from 'recoil'
 import { appThemeState } from '@/recoil/app-theme/app-theme.state'
 import AppbarMainLogo from './index.main-logo'
+import { useSync } from '@/hooks/sync/use-sync.hook'
 
 const PRIVATE_TITLE = `Consistency GPT (Beta)`
 const PRIVATE_SHORTER_TITLE = `CGT`
@@ -26,6 +27,8 @@ interface Props {
 }
 const Appbar: FC<Props> = ({ children, nickname }) => {
   const appTheme = useRecoilValue(appThemeState)
+  useSync()
+
   const { width } = useWindowSize()
 
   return (

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -56,7 +56,7 @@ const SettingFrame: FC = () => {
         title={`Back to main page`}
         onClick={onClickToHomePage}
       />
-      <Paper style={{ width: `100%`, maxWidth: 700, padding: 16 }}>
+      <Paper sx={{ width: '100%', maxWidth: 700, p: 2 }}>
         <UseProgressDialogSwitch />
       </Paper>
       <ThemedTextButtonAtom title={`Save`} onClick={onClickSave} />

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -56,7 +56,7 @@ const SettingFrame: FC = () => {
         title={`Back to main page`}
         onClick={onClickToHomePage}
       />
-      <Paper sx={{ width: '100%', maxWidth: 700, p: 2 }}>
+      <Paper sx={{ width: `100%`, maxWidth: 700, p: 2 }}>
         <UseProgressDialogSwitch />
       </Paper>
       <ThemedTextButtonAtom title={`Save`} onClick={onClickSave} />

--- a/src/components/organism_setting_frame/index.tsx
+++ b/src/components/organism_setting_frame/index.tsx
@@ -1,7 +1,7 @@
 import { FC, useCallback, useState } from 'react'
 import { actionGroupIdsState } from '@/recoil/action-groups/action-groups.state'
 import { useRecoilCallback, useRecoilValue } from 'recoil'
-import { List, ListItem, ListItemText, Stack } from '@mui/material'
+import { List, ListItem, ListItemText, Paper, Stack } from '@mui/material'
 import SettingFrameRefresher from './index.setting-refresher'
 import StyledIconButtonAtom from '@/atoms/StyledIconButton'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
@@ -11,6 +11,7 @@ import { usePatchRitual } from '@/hooks/ritual/use-patch-ritual.hook'
 import ThemedTextButtonAtom from '@/atoms_themed/ThemedTextButton'
 import { useRouter } from 'next/router'
 import { PageConst } from '@/constants/pages.constant'
+import UseProgressDialogSwitch from '../atom_use_progress_dialog_switch'
 
 const SettingFrame: FC = () => {
   const actionGroupIds = useRecoilValue(actionGroupIdsState)
@@ -55,6 +56,9 @@ const SettingFrame: FC = () => {
         title={`Back to main page`}
         onClick={onClickToHomePage}
       />
+      <Paper style={{ width: `100%`, maxWidth: 700, padding: 16 }}>
+        <UseProgressDialogSwitch />
+      </Paper>
       <ThemedTextButtonAtom title={`Save`} onClick={onClickSave} />
       <List sx={{ width: `100%`, maxWidth: 700, bgcolor: `background.paper` }}>
         {actionGroupIds.map((id, i) => (

--- a/src/hooks/sync/README.md
+++ b/src/hooks/sync/README.md
@@ -1,0 +1,11 @@
+# Sync Directory
+
+<!-- TOC -->
+
+- [Sync Directory](#sync-directory)
+  - [Overview](#overview)
+
+<!-- /TOC -->
+
+## Overview
+The `sync` directory contains hooks and components related to synchronization features in the application. It includes functionality for managing preferences, observing elements, and handling progress dialogs. `Sync` is basically the parent directory for all business-logic included hooks in the app.

--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -4,22 +4,25 @@ import { usePreference } from '../preference/use-preference.hook'
 // Initializes preference state on component mount
 // This hook should not be used in multiple places simultaneously because it relies on shared state.
 // Using it in multiple places could lead to race conditions or inconsistent state updates.
-let isSyncInUse = false; // Tracks whether the hook is already in use
+// And therefore it is designed to be used in a single component or context where preference state is managed.
+let isSyncInUse = false // Tracks whether the hook is already in use
 
 export const useSync = (): void => {
-  if (isSyncInUse) {
-    throw new Error('useSync hook is already in use. Avoid using it in multiple components simultaneously.');
-  }
-  isSyncInUse = true;
+  if (isSyncInUse)
+    throw new Error(
+      `useSync hook is already in use. Avoid using it in multiple components simultaneously.`,
+    )
+  isSyncInUse = true
 
-  const onGetPreference = usePreference();
+  const onGetPreference = usePreference()
 
   useEffect(() => {
     // update preference state by default:
-    onGetPreference();
+    onGetPreference()
 
+    // Cleanup:
     return () => {
-      isSyncInUse = false; // Reset the flag when the component unmounts
-    };
-  }, [onGetPreference]);
+      isSyncInUse = false // Reset the flag when the component unmounts
+    }
+  }, [onGetPreference])
 }

--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -2,12 +2,24 @@ import { useEffect } from 'react'
 import { usePreference } from '../preference/use-preference.hook'
 
 // Initializes preference state on component mount
-// This hook should not be used in multiple places simultaneously
+// This hook should not be used in multiple places simultaneously because it relies on shared state.
+// Using it in multiple places could lead to race conditions or inconsistent state updates.
+let isSyncInUse = false; // Tracks whether the hook is already in use
+
 export const useSync = (): void => {
-  const onGetPreference = usePreference()
+  if (isSyncInUse) {
+    throw new Error('useSync hook is already in use. Avoid using it in multiple components simultaneously.');
+  }
+  isSyncInUse = true;
+
+  const onGetPreference = usePreference();
 
   useEffect(() => {
     // update preference state by default:
-    onGetPreference()
-  }, [onGetPreference])
+    onGetPreference();
+
+    return () => {
+      isSyncInUse = false; // Reset the flag when the component unmounts
+    };
+  }, [onGetPreference]);
 }

--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import { usePreference } from '../preference/use-preference.hook'
 
-// useSync runs only once
-// This may not exist in multiple places
+// Initializes preference state on component mount
+// This hook should not be used in multiple places simultaneously
 export const useSync = (): void => {
   const onGetPreference = usePreference()
 

--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+import { usePreference } from '../preference/use-preference.hook'
+
+// useSync runs only once
+// This may not exist in multiple places
+export const useSync = (): void => {
+  const onGetPreference = usePreference()
+
+  useEffect(() => {
+    // update preference state by default:
+    onGetPreference()
+  }, [onGetPreference])
+}


### PR DESCRIPTION
# Background
We want users to modify their setting in the setting page of the CGT application. Design however is not the consideration in this PR.

## What's done?
You can now modify `useProgressDialog` in the setting page:

<img width="2042" height="438" alt="image" src="https://github.com/user-attachments/assets/cc376646-7c1c-42c3-8ec7-79eb25692224" />


## What are the related PRs?
None

## What's next?
Maybe better design, but not the most important thing.

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


