### PR TITLE
Feat: `useSync` with code based checker removed

### DIFF
--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -1,7 +1,11 @@
 import { useEffect } from 'react'
 import { usePreference } from '../preference/use-preference.hook'
 
-// Do NOT use useSync more than once in the same page
+// Do NOT use useSync more than once in the same page.
+// Using useSync multiple times can lead to redundant or conflicting state updates,
+// performance degradation, and unexpected behavior due to multiple useEffect calls.
+// Note: The enforcement mechanism to prevent multiple useSync calls has been removed,
+// so it is the developer's responsibility to ensure it is used only once per page.
 export const useSync = (): void => {
   const onGetPreference = usePreference()
 

--- a/src/hooks/sync/use-sync.hook.ts
+++ b/src/hooks/sync/use-sync.hook.ts
@@ -1,28 +1,12 @@
 import { useEffect } from 'react'
 import { usePreference } from '../preference/use-preference.hook'
 
-// Initializes preference state on component mount
-// This hook should not be used in multiple places simultaneously because it relies on shared state.
-// Using it in multiple places could lead to race conditions or inconsistent state updates.
-// And therefore it is designed to be used in a single component or context where preference state is managed.
-let isSyncInUse = false // Tracks whether the hook is already in use
-
+// Do NOT use useSync more than once in the same page
 export const useSync = (): void => {
-  if (isSyncInUse)
-    throw new Error(
-      `useSync hook is already in use. Avoid using it in multiple components simultaneously.`,
-    )
-  isSyncInUse = true
-
   const onGetPreference = usePreference()
 
   useEffect(() => {
     // update preference state by default:
     onGetPreference()
-
-    // Cleanup:
-    return () => {
-      isSyncInUse = false // Reset the flag when the component unmounts
-    }
   }, [onGetPreference])
 }


### PR DESCRIPTION
# Background
The intention behind `useSync`—systematically checking whether it’s used across multiple phases—was good. However, it didn’t work well during the development phase, which defeats the purpose of having it in the first place.

## What's done?
Remove the systematical checking mechanism out of `useSync`

## What are the related PRs?
None

## What's next?
None

## Checklist Before PR Review
- [x] The following has been handled:
  - `Title` is checked
  - `Background` is filled
  - `What's done?` is filled
  - `What are the related PRs?` is filled
  - `What's next?` is filled
  - `Draft` is set for this PR
  - `Assignee` is set
  - `Labels` are set
  - `Development` is linked if related issue exists

## Checklist (Right Before PR Review Request)
- [x] The following has been handled:
  - Final Operation Check is done
  - Mobile View Operation Check is done, if frontend related
  - Make this PR as an open PR
  - Double-check `What's done?` matches to the actual changes
  - Appropriate ajktown/docs sync pr done if needed

## Checklist (Reviewers)
- [x] Review if the following has been handled:
  - Review Code
  - `Checklist Before PR Review` is correctly handled
  - `Checklist (Right Before PR Review Request)` is correctly handled
  - Check if there are any other missing TODOs (Checklists) that are not yet listed
  - Check if issue under `Development` is fully handled if exists
  - Check if appropriate issues are created from `What's next?`


